### PR TITLE
fix: release.yml by moving semantic-release dependencies back to root

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
     "eslint-plugin-unused-imports": "^4.1.3",
     "nx": "19.6.0",
     "prettier": "^3.3.3",
+    "semantic-release": "^24.0.0",
+    "semantic-release-monorepo": "^8.0.2",
     "typescript": "^5.6.2",
     "typescript-eslint": "^8.1.0"
   }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -68,8 +68,6 @@
     "concurrently": "^8.2.2",
     "dev-utils": "workspace:*",
     "graphql": "^16.9.0",
-    "semantic-release": "^24.0.0",
-    "semantic-release-monorepo": "^8.0.2",
     "typescript": "^5.6.2",
     "vite": "^5.4.1"
   },

--- a/packages/plugin-sequelize/package.json
+++ b/packages/plugin-sequelize/package.json
@@ -59,8 +59,6 @@
     "graphql": "^16.9.0",
     "graphql-gene": "workspace:*",
     "nodemon": "^3.1.4",
-    "semantic-release": "^24.0.0",
-    "semantic-release-monorepo": "^8.0.2",
     "sequelize": "^6.37.3",
     "sequelize-typescript": "^2.1.6",
     "typescript": "^5.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,12 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.3.3
+      semantic-release:
+        specifier: ^24.0.0
+        version: 24.1.0(typescript@5.6.2)
+      semantic-release-monorepo:
+        specifier: ^8.0.2
+        version: 8.0.2(semantic-release@24.1.0(typescript@5.6.2))
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -72,12 +78,6 @@ importers:
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
-      semantic-release:
-        specifier: ^24.0.0
-        version: 24.1.0(typescript@5.6.2)
-      semantic-release-monorepo:
-        specifier: ^8.0.2
-        version: 8.0.2(semantic-release@24.1.0(typescript@5.6.2))
       typescript:
         specifier: ^5.6.2
         version: 5.6.2
@@ -128,12 +128,6 @@ importers:
       nodemon:
         specifier: ^3.1.4
         version: 3.1.4
-      semantic-release:
-        specifier: ^24.0.0
-        version: 24.1.0(typescript@5.6.2)
-      semantic-release-monorepo:
-        specifier: ^8.0.2
-        version: 8.0.2(semantic-release@24.1.0(typescript@5.6.2))
       sequelize:
         specifier: ^6.37.3
         version: 6.37.3
@@ -1493,10 +1487,6 @@ packages:
 
   glob@7.2.0:
     resolution: {integrity: sha512-lmLf6gtyrPq8tTjSmrO94wBeQbFR3HbLHbuyD69wuyQkImp2hWqMGB47OX65FBkPffO641IP9jWa1z4ivqG26Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
-
-  glob@7.2.3:
-    resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
     deprecated: Glob versions prior to v9 are no longer supported
 
   globals@14.0.0:
@@ -4372,15 +4362,6 @@ snapshots:
       once: 1.4.0
       path-is-absolute: 1.0.1
 
-  glob@7.2.3:
-    dependencies:
-      fs.realpath: 1.0.0
-      inflight: 1.0.6
-      inherits: 2.0.4
-      minimatch: 3.1.2
-      once: 1.4.0
-      path-is-absolute: 1.0.1
-
   globals@14.0.0: {}
 
   globby@11.1.0:
@@ -5171,7 +5152,7 @@ snapshots:
 
   rimraf@3.0.2:
     dependencies:
-      glob: 7.2.3
+      glob: 7.2.0
 
   rollup@4.20.0:
     dependencies:


### PR DESCRIPTION
As per the title