### PR TITLE
fix: use PR title as squashed commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,7 @@ jobs:
         if: steps.public-package-affected.outputs.count > 0 || ${{ env.CI_FORCE_RELEASE_RUN }} == 'true'
         run: pnpm build
 
+      #
       # A release is made if the prefix is feat, fix, perf, chore(deps), or docs(README)
       #
       # { type: 'feat', release: 'minor' },


### PR DESCRIPTION
As per the title (in order to trigger `semantic-release`

The changes were made in the repository settings so this PR only adds a dummy comment to trigger the workflow again.