### PR TITLE
fix: remove dummy change from both packages to trigger release

### DIFF
--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -2,7 +2,7 @@ import { generateViteConfig } from 'dev-utils'
 
 export default generateViteConfig({
   absoluteRootDir: __dirname,
-  formats: ['es', 'cjs'], // support both formats
+  formats: ['es', 'cjs'],
   pluginCategories: ['dts'],
   isLibrary: true,
 })

--- a/packages/plugin-sequelize/vite.config.ts
+++ b/packages/plugin-sequelize/vite.config.ts
@@ -2,7 +2,7 @@ import { generateViteConfig } from 'dev-utils'
 
 export default generateViteConfig({
   absoluteRootDir: __dirname,
-  formats: ['es', 'cjs'], // support both formats
+  formats: ['es', 'cjs'],
   pluginCategories: ['dts'],
   isLibrary: true,
 })


### PR DESCRIPTION
The previous release worked for the core package, but not for the sequelize plugin as the organization was not created in npm yet. Should work as expected now.