### PR TITLE
fix: publishing plugin with public access

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,4 +86,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: pnpm -r --workspace-concurrency=1 exec semantic-release -e semantic-release-monorepo
+        run: pnpm -r --filter='!dev-*' --workspace-concurrency=1 exec semantic-release -e semantic-release-monorepo

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -71,6 +71,9 @@
     "typescript": "^5.6.2",
     "vite": "^5.4.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "release": {
     "extends": "semantic-release-monorepo",
     "branches": [

--- a/packages/plugin-sequelize/package.json
+++ b/packages/plugin-sequelize/package.json
@@ -64,6 +64,9 @@
     "typescript": "^5.6.2",
     "vite": "^5.4.1"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "release": {
     "extends": "semantic-release-monorepo",
     "branches": [


### PR DESCRIPTION
I was getting an error when publishing `@graphql-gene/plugin-sequelize` because it seems like organization packages are treated as private package by default. We need to explicitly set the access to "public".

See https://stackoverflow.com/a/59711239/1895428

<img width="1294" alt="image" src="https://github.com/user-attachments/assets/d534e0b3-6c17-4044-87bf-7f853796a5d1">
