### PR TITLE
fix: inferring args types without `as const`

### DIFF
--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -8,6 +8,7 @@ import type {
   GraphqlTypes,
   GraphQLVarType,
   InferFields,
+  Narrow,
   OperatorInputs,
   SomeRequired,
   ValidGraphqlType,
@@ -138,7 +139,7 @@ export type GeneTypeConfig<
     | GeneResolver<
         TSource,
         TContext,
-        TArgDefs extends 'default'
+        TArgDefs extends `${GENE_RESOLVER_TEMPLATES.default}`
           ? GeneDefaultResolverArgs<
               TReturnType extends string ? NonNullable<GraphqlToTypescript<TReturnType>> : unknown
             >
@@ -275,7 +276,7 @@ export function defineField<
   TArgDefs extends ArgsDefinition,
   TReturnType extends GraphqlReturnTypes<ValidGraphqlType>,
   TContext = GeneContext,
->(config: FieldConfig<TSource, TContext, TArgDefs, TReturnType>) {
+>(config: Narrow<FieldConfig<TSource, TContext, TArgDefs, TReturnType>>) {
   /**
    * We need to infer `TArgDefs` to use accurate types inside the resolver function, but we want
    * "defineField" to return a generic `Record<string, unknown>` as ArgDefs to allow adding the

--- a/packages/core/src/types/typeUtils.ts
+++ b/packages/core/src/types/typeUtils.ts
@@ -34,3 +34,25 @@ type TrimHyphen<T extends string> = T extends `-${infer R}` ? R : T
 
 export type Kebab<T extends string, A extends string = ''> = TrimHyphen<Hyphenize<T, A>>
 export type NeverToUnknown<T> = T extends never ? unknown : T
+
+type Try<A1, A2, Catch = never> = A1 extends A2 ? A1 : Catch
+
+type Narrowable = string | number | bigint | boolean
+
+type NarrowRaw<A> =
+  | (A extends [] ? [] : never)
+  | (A extends Narrowable ? A : never)
+  | {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
+      [K in keyof A]: A[K] extends Function ? A[K] : NarrowRaw<A[K]>
+    }
+
+/**
+ * Allow you to infer the values of an object inside another object without using `as const`.
+ *
+ * @example
+ * type Example = Narrow<{ args: { page: 'Int' } }>
+ *
+ * // Example['args'] will be of type `{ email: 'Int' }` instead of `{ email: string }`
+ */
+export type Narrow<A> = Try<A, [], NarrowRaw<A>>


### PR DESCRIPTION
Previously, we were forced to define the `args` object with `as const` even when the field was defined with `defineField`. This PR fixes it.

The `args` will now be inferred for the resolver without using `as const` if defined with `defineField`.
