### PR TITLE
fix: resolvers not defined when returning boolean

### DIFF
--- a/packages/core/src/resolvers.ts
+++ b/packages/core/src/resolvers.ts
@@ -90,10 +90,10 @@ function defineResolvers<SchemaTypes extends AnyObject>(options: {
       const returnTypeName = getReturnTypeName(normalizedConfig.returnType)
       const model = options.types[returnTypeName] as GraphqlTypes[keyof GraphqlTypes] | undefined
 
-      if (type !== returnTypeName || !model) return
+      if (type !== returnTypeName) return
 
-      const geneConfig = getGeneConfigFromOptions({ model })
-      const plugin = options.plugins.find(plugin => plugin.isMatching(model))
+      const geneConfig = model ? getGeneConfigFromOptions({ model }) : undefined
+      const plugin = model ? options.plugins.find(plugin => plugin.isMatching(model)) : undefined
 
       const directiveConfigs: GeneConfig['directives'] = []
 


### PR DESCRIPTION
We were not defining the resolver when no model was found based on the `returnType`, but the return type can be a native GraphQL type like `Boolean`. So we can't define a `default` resolver when the field returns a boolean, but we should still proceed with defining the resolver.