### PR TITLE
fix: offset filter wrongly set to next page

### DIFF
--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -182,6 +182,12 @@ export function isObject<T>(variable: T) {
   return variable !== null && typeof variable === 'object'
 }
 
+export function isEmptyObject<T extends object>(obj: T) {
+  for (const _prop in obj) return false
+
+  return true
+}
+
 export function isArrayFieldConfig<T>(
   fieldConfigs: T
 ): fieldConfigs is Extract<T, readonly string[]> {

--- a/packages/plugin-sequelize/package.json
+++ b/packages/plugin-sequelize/package.json
@@ -51,7 +51,7 @@
   },
   "peerDependencies": {
     "graphql": "16.x",
-    "graphql-gene": "^1.1.0-beta.3",
+    "graphql-gene": "^1.1.0-beta.4",
     "sequelize": "6.x",
     "sequelize-typescript": "2.x"
   },

--- a/packages/plugin-sequelize/src/utils/internal.ts
+++ b/packages/plugin-sequelize/src/utils/internal.ts
@@ -49,3 +49,9 @@ export function populateWhereOptions<M>(
     }
   }
 }
+
+export function isEmptyObject<T extends object>(obj: T) {
+  for (const _prop in obj) return false
+
+  return true
+}

--- a/packages/plugin-sequelize/src/utils/internal.ts
+++ b/packages/plugin-sequelize/src/utils/internal.ts
@@ -49,9 +49,3 @@ export function populateWhereOptions<M>(
     }
   }
 }
-
-export function isEmptyObject<T extends object>(obj: T) {
-  for (const _prop in obj) return false
-
-  return true
-}

--- a/packages/plugin-sequelize/src/utils/public.ts
+++ b/packages/plugin-sequelize/src/utils/public.ts
@@ -4,12 +4,13 @@ import { lookahead, lookDeeper } from 'graphql-lookahead'
 import type { IncludeOptions, OrderItem } from 'sequelize'
 import type { Model } from 'sequelize-typescript'
 import type { GeneSequelizeWhereOptions } from '../types'
-import { populateWhereOptions } from './internal'
+import { populateWhereOptions, isEmptyObject } from './internal'
 
 type DefaultResolverIncludeOptions = Pick<
   IncludeOptions,
-  'where' | 'order' | 'association' | 'include' | 'limit'
+  'where' | 'order' | 'association' | 'limit'
 > & {
+  include?: DefaultResolverIncludeOptions[]
   /**
    * "offset" is missing in IncludeOptions
    * @see https://github.com/sequelize/sequelize/issues/12969
@@ -46,7 +47,10 @@ export function getQueryInclude(info: GraphQLResolveInfo) {
       return include
     },
   })
-  return includeOptions
+
+  return isEmptyObject(includeOptions)
+    ? undefined
+    : (includeOptions as Required<Pick<typeof includeOptions, 'include'>>)
 }
 
 export function getQueryIncludeOf(
@@ -92,7 +96,9 @@ export function getQueryIncludeOf(
     lookahead(lookDeeperOptions)
   }
 
-  return includeOptions
+  return isEmptyObject(includeOptions)
+    ? undefined
+    : (includeOptions as Required<Pick<typeof includeOptions, 'include'>>)
 }
 
 export function getFieldFindOptions(options: {
@@ -150,5 +156,6 @@ export function getFieldIncludeOptions(options: {
     includeOptions.offset = options.args.page * options.args.perPage
     includeOptions.limit = options.args.perPage
   }
+
   return includeOptions
 }

--- a/packages/plugin-sequelize/src/utils/public.ts
+++ b/packages/plugin-sequelize/src/utils/public.ts
@@ -1,10 +1,10 @@
 import { GraphQLError, isListType as isListTypeObject, type GraphQLResolveInfo } from 'graphql'
-import { isObject, QUERY_ORDER_VALUES, type ValidGraphqlType } from 'graphql-gene'
+import { isEmptyObject, isObject, QUERY_ORDER_VALUES, type ValidGraphqlType } from 'graphql-gene'
 import { lookahead, lookDeeper } from 'graphql-lookahead'
 import type { IncludeOptions, OrderItem } from 'sequelize'
 import type { Model } from 'sequelize-typescript'
 import type { GeneSequelizeWhereOptions } from '../types'
-import { populateWhereOptions, isEmptyObject } from './internal'
+import { populateWhereOptions } from './internal'
 
 type DefaultResolverIncludeOptions = Pick<
   IncludeOptions,

--- a/packages/plugin-sequelize/src/utils/public.ts
+++ b/packages/plugin-sequelize/src/utils/public.ts
@@ -153,7 +153,7 @@ export function getFieldIncludeOptions(options: {
   // Both "page" and "perPage" arguments have default values so they should always be numbers
   // if they are valid.
   if (typeof options.args.page === 'number' && typeof options.args.perPage === 'number') {
-    includeOptions.offset = options.args.page * options.args.perPage
+    includeOptions.offset = (options.args.page - 1) * options.args.perPage
     includeOptions.limit = options.args.perPage
   }
 


### PR DESCRIPTION
The offset value was defined with `args.page * args.perPage`, but should be `(args.page - 1) * args.perPage` (it should be equal to `0` for page 1).

Also improve typing of `getQueryIncludeOf`.