### PR TITLE
feat: allow providing resolvers to generateSchema

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ import * as graphqlTypes from '../models/graphqlTypes'
 
 const {
   typeDefs,
-  resolvers: generatedResolvers,
+  resolvers,
   schema,
   schemaString,
   schemaHtml,
@@ -156,16 +156,14 @@ const {
   schema: [DateTypeDefinition, DateTimeTypeDefinition, JSONDefinition].join(
     '\n'
   ),
+  resolvers: {
+    Date: DateResolver,
+    DateTime: DateTimeResolver,
+    JSON: JSONResolver,
+  },
   plugins: [pluginSequelize()],
   types: graphqlTypes,
 })
-
-const resolvers = {
-  Date: DateResolver,
-  DateTime: DateTimeResolver,
-  JSON: JSONResolver,
-  ...generatedResolvers,
-}
 
 export { typeDefs, resolvers, schema, schemaString, schemaHtml }
 ```

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ export class User extends Model {
 
   static readonly geneConfig = defineGraphqlGeneConfig(User, {
     // Your config
-  }
+  })
 }
 
 extendTypes({
@@ -564,7 +564,7 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
         directives: [userAuthDirective({ role: null })],
       },
     },
-  }
+  })
 }
 
 extendTypes({
@@ -601,7 +601,7 @@ Another example for `superAdmin` role:
 static readonly geneConfig = defineGraphqlGeneConfig(AdminAccount, {
   // i.e. Only allow super admin users to access the `AdminAccount` data
   directives: [userAuthDirective({ role: 'superAdmin' })],
-}
+})
 ```
 
 <br>

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -148,7 +148,7 @@ import * as graphqlTypes from '../models/graphqlTypes'
 
 const {
   typeDefs,
-  resolvers: generatedResolvers,
+  resolvers,
   schema,
   schemaString,
   schemaHtml,
@@ -156,16 +156,14 @@ const {
   schema: [DateTypeDefinition, DateTimeTypeDefinition, JSONDefinition].join(
     '\n'
   ),
+  resolvers: {
+    Date: DateResolver,
+    DateTime: DateTimeResolver,
+    JSON: JSONResolver,
+  },
   plugins: [pluginSequelize()],
   types: graphqlTypes,
 })
-
-const resolvers = {
-  Date: DateResolver,
-  DateTime: DateTimeResolver,
-  JSON: JSONResolver,
-  ...generatedResolvers,
-}
 
 export { typeDefs, resolvers, schema, schemaString, schemaHtml }
 ```

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -354,7 +354,7 @@ export class User extends Model {
 
   static readonly geneConfig = defineGraphqlGeneConfig(User, {
     // Your config
-  }
+  })
 }
 
 extendTypes({
@@ -564,7 +564,7 @@ class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
         directives: [userAuthDirective({ role: null })],
       },
     },
-  }
+  })
 }
 
 extendTypes({
@@ -601,7 +601,7 @@ Another example for `superAdmin` role:
 static readonly geneConfig = defineGraphqlGeneConfig(AdminAccount, {
   // i.e. Only allow super admin users to access the `AdminAccount` data
   directives: [userAuthDirective({ role: 'superAdmin' })],
-}
+})
 ```
 
 <br>

--- a/packages/core/src/utils/index.ts
+++ b/packages/core/src/utils/index.ts
@@ -21,7 +21,6 @@ import type { AnyObject, FieldLines, GraphQLVarType, TypeDefLines } from '../typ
 import type { GeneConfig, GeneTypeConfig } from '../defineConfig'
 
 export * from './extend'
-export * from './operators'
 
 type GraphQLOutputObjectType = GraphQLObjectType | GraphQLInterfaceType
 
@@ -216,6 +215,22 @@ export function isListType(type: ReturnType<typeof parseType>) {
 
 export function findTypeNameFromTypeNode(type: ReturnType<typeof parseType>): string {
   return 'type' in type ? findTypeNameFromTypeNode(type.type) : type.name.value
+}
+
+export function getFieldDefinition(options: {
+  schema: GraphQLSchema
+  parent: string
+  field: string
+}) {
+  const typeDefinition = options.schema.getType(options.parent)
+
+  // // This should only happen if the provided parent type is invalid
+  if (!typeDefinition) return
+
+  const fields = 'getFields' in typeDefinition ? typeDefinition.getFields() : undefined
+  const fieldDef = fields?.[options.field]
+
+  return fieldDef && 'resolve' in fieldDef ? fieldDef : undefined
 }
 
 /**


### PR DESCRIPTION
Add the option `resolvers` to `generateSchema` to allow providing custom resolvers or scalar types to the initial schema. This also allows to provide scalars and use the `schema` returned by `generateSchema`. It was previously missing from the `schema` returned so we were forced to use the returned `typeDefs` and `resolvers` instead of `schema`.