### PR TITLE
fix: wrong resolver return value not raised by TS

### DIFF
--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -15,7 +15,8 @@ import type {
 } from './types'
 import type { GENE_RESOLVER_TEMPLATES, QUERY_ORDER_ENUM } from './constants'
 
-type ArgsDefinition = Record<string, string> | `${GENE_RESOLVER_TEMPLATES}` | undefined
+type ArgsDefinition<V = string> = Record<string, V> | `${GENE_RESOLVER_TEMPLATES}` | undefined
+type StrictArgsDefinition = ArgsDefinition<GraphqlReturnTypes<ValidGraphqlType>>
 
 export type GeneConfigTypes<
   TSource = Record<string, unknown> | undefined,
@@ -273,10 +274,10 @@ export function defineDirective<
 
 export function defineField<
   TSource extends Record<string, unknown> | undefined,
-  TArgDefs extends ArgsDefinition,
+  TArgDefs extends StrictArgsDefinition,
   TReturnType extends GraphqlReturnTypes<ValidGraphqlType>,
   TContext = GeneContext,
->(config: Narrow<FieldConfig<TSource, TContext, TArgDefs, TReturnType>>) {
+>(config: Narrow<FieldConfig<TSource, TContext, TArgDefs, TReturnType>, 'args' | 'returnType'>) {
   /**
    * We need to infer `TArgDefs` to use accurate types inside the resolver function, but we want
    * "defineField" to return a generic `Record<string, unknown>` as ArgDefs to allow adding the

--- a/packages/core/src/types/typeUtils.ts
+++ b/packages/core/src/types/typeUtils.ts
@@ -35,24 +35,21 @@ type TrimHyphen<T extends string> = T extends `-${infer R}` ? R : T
 export type Kebab<T extends string, A extends string = ''> = TrimHyphen<Hyphenize<T, A>>
 export type NeverToUnknown<T> = T extends never ? unknown : T
 
-type Try<A1, A2, Catch = never> = A1 extends A2 ? A1 : Catch
-
-type Narrowable = string | number | bigint | boolean
-
-type NarrowRaw<A> =
-  | (A extends [] ? [] : never)
-  | (A extends Narrowable ? A : never)
-  | {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-      [K in keyof A]: A[K] extends Function ? A[K] : NarrowRaw<A[K]>
-    }
-
 /**
  * Allow you to infer the values of an object inside another object without using `as const`.
  *
  * @example
- * type Example = Narrow<{ args: { page: 'Int' } }>
+ * function doSomething<T>(obj: Narrow<T>) {
+ *   return obj
+ * }
+ * const something = doSomething({ args: { page: 'Int' } })
  *
- * // Example['args'] will be of type `{ email: 'Int' }` instead of `{ email: string }`
+ * // `something.args.page` will be of type `'Int'` instead of `string`
+ *
+ * @see https://stackoverflow.com/a/75881801/1895428
  */
-export type Narrow<A> = Try<A, [], NarrowRaw<A>>
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+export type Narrow<T, SpecificProps = any> =
+  | (T extends infer U ? U : never)
+  | Extract<T, number | string | boolean | bigint | symbol | null | undefined | []>
+  | ([T] extends [[]] ? [] : { [K in keyof T]: K extends SpecificProps ? Narrow<T[K]> : never })


### PR DESCRIPTION
As per the title

Also raise when defining an argument with an invalid GraphQL type (i.e. `args: { foo: 'String', typo: 'Strnig' }`)