### PR TITLE
fix: field config type accuracy when calling extendTypes

### DIFF
--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -5,11 +5,11 @@ import type {
   GraphqlReturnTypes,
   GraphqlToTypescript,
   GraphqlTypeName,
-  GraphqlTypes,
   GraphQLVarType,
   InferFields,
   Narrow,
   OperatorInputs,
+  Prop,
   SomeRequired,
   ValidGraphqlType,
 } from './types'
@@ -38,36 +38,55 @@ export type GeneObjectTypeConfig<
   | GeneTypeConfig<TSource, TContext, TArgDefs, TReturnType>
 >
 
-/** Query and Mutation types extended from different models. */
+type FallbackIfInvalid<T, TFallback> = T extends never ? TFallback : T
+type AccurateTypeSource<
+  TTypeName,
+  TFallbackSource = Record<string, unknown> | undefined,
+> = TTypeName extends 'Query' | 'Mutation'
+  ? undefined
+  : TTypeName extends string
+    ? FallbackIfInvalid<NonNullable<GraphqlToTypescript<TTypeName>>, TFallbackSource>
+    : TFallbackSource
+
 export type ExtendedTypes<
   TSource = Record<string, unknown> | undefined,
   TContext = GeneContext,
   TArgDefs extends ArgsDefinition = undefined,
   TReturnType extends string | unknown = unknown,
 > = {
-  [k in 'Query' | 'Mutation']?: Record<
+  [typeName in GraphqlTypeName]?: Record<
     GraphQLFieldName,
     FieldConfig<
-      TSource,
+      AccurateTypeSource<typeName, TSource>,
       TContext,
       undefined extends TArgDefs ? ArgsDefinition : TArgDefs,
       TReturnType extends unknown ? GraphqlReturnTypes<ValidGraphqlType> : TReturnType
     >
   >
-} & {
-  [typeName in GraphqlTypeName]?: Record<
-    GraphQLFieldName,
-    Omit<
-      GeneTypeConfig<
-        TSource,
-        TContext,
-        undefined extends TArgDefs ? ArgsDefinition : TArgDefs,
-        GraphqlTypes[typeName]
-      >,
-      'returnType'
-    >
-  >
 }
+
+export type NarrowExtendedTypes<TTypes extends Record<string, Record<string, object>>> = {
+  [TypeName in keyof TTypes]?: {
+    [FieldName in keyof TTypes[TypeName]]: ExtendedTypeField<TTypes[TypeName][FieldName], TypeName>
+  }
+}
+
+export type ExtendedTypeField<T, TypeName> = {
+  [K in keyof T]: K extends 'resolver'
+    ? GeneResolverOption<
+        AccurateTypeSource<TypeName>,
+        GeneContext,
+        Prop<T, 'args'> extends ArgsDefinition ? Prop<T, 'args'> : never,
+        Prop<T, 'returnType'>
+      >
+    : Narrow<T[K]>
+}
+
+export type StrictExtendedTypes<
+  TSource = Record<string, unknown> | undefined,
+  TContext = GeneContext,
+  TArgDefs extends ArgsDefinition = undefined,
+> = ExtendedTypes<TSource, TContext, TArgDefs, GraphqlReturnTypes<ValidGraphqlType>>
 
 export interface GeneConfig<
   M = unknown,
@@ -136,24 +155,7 @@ export type GeneTypeConfig<
   directives?: GeneDirectiveConfig[]
   args?: TArgDefs extends undefined ? undefined : TArgDefs
   returnType: TReturnType extends unknown ? GraphqlReturnTypes<ValidGraphqlType> : TReturnType
-  resolver?:
-    | GeneResolver<
-        TSource,
-        TContext,
-        TArgDefs extends `${GENE_RESOLVER_TEMPLATES.default}`
-          ? GeneDefaultResolverArgs<
-              TReturnType extends string ? NonNullable<GraphqlToTypescript<TReturnType>> : unknown
-            >
-          : TArgDefs extends undefined
-            ? Record<string, unknown> | undefined
-            : {
-                [k in keyof TArgDefs]: TArgDefs[k] extends string
-                  ? GraphqlToTypescript<TArgDefs[k]>
-                  : unknown
-              },
-        TReturnType extends string ? GraphqlToTypescript<TReturnType> : unknown
-      >
-    | `${GENE_RESOLVER_TEMPLATES}`
+  resolver?: GeneResolverOption<TSource, TContext, TArgDefs, TReturnType>
 }
 
 export type FieldConfig<
@@ -164,6 +166,30 @@ export type FieldConfig<
 > =
   | GraphqlReturnTypes<ValidGraphqlType>
   | SomeRequired<GeneTypeConfig<TSource, TContext, TArgDefs, TReturnType>, 'resolver'>
+
+type GeneResolverOption<
+  TSource = Record<string, unknown> | undefined,
+  TContext = GeneContext,
+  TArgDefs extends ArgsDefinition = undefined,
+  TReturnType extends string | unknown = unknown,
+> =
+  | GeneResolver<
+      TSource,
+      TContext,
+      TArgDefs extends `${GENE_RESOLVER_TEMPLATES.default}`
+        ? GeneDefaultResolverArgs<
+            TReturnType extends string ? NonNullable<GraphqlToTypescript<TReturnType>> : unknown
+          >
+        : TArgDefs extends undefined
+          ? Record<string, unknown> | undefined
+          : {
+              [k in keyof Narrow<TArgDefs>]: Narrow<TArgDefs>[k] extends string
+                ? GraphqlToTypescript<Narrow<TArgDefs>[k]>
+                : unknown
+            },
+      TReturnType extends string ? GraphqlToTypescript<TReturnType> : unknown
+    >
+  | `${GENE_RESOLVER_TEMPLATES}`
 
 export type GeneResolver<
   TSource = Record<string, unknown> | undefined,
@@ -272,18 +298,18 @@ export function defineDirective<
   return directive
 }
 
+/**
+ * @deprecated Field config passed to `extendTypes` don't need to be wrapped with `defineField`
+ * anymore in order to be accurate (they are now even better typed without it).
+ */
 export function defineField<
   TSource extends Record<string, unknown> | undefined,
   TArgDefs extends StrictArgsDefinition,
   TReturnType extends GraphqlReturnTypes<ValidGraphqlType>,
   TContext = GeneContext,
 >(config: Narrow<FieldConfig<TSource, TContext, TArgDefs, TReturnType>, 'args' | 'returnType'>) {
-  /**
-   * We need to infer `TArgDefs` to use accurate types inside the resolver function, but we want
-   * "defineField" to return a generic `Record<string, unknown>` as ArgDefs to allow adding the
-   * field config to `defineGraphqlGeneConfig` (where `args` doesn't need accurate typing).
-   */
-  return config as FieldConfig<TSource, TContext, ArgsDefinition, TReturnType>
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  return config as FieldConfig<any, TContext, ArgsDefinition, TReturnType>
 }
 
 export function defineType<

--- a/packages/core/src/types/typeUtils.ts
+++ b/packages/core/src/types/typeUtils.ts
@@ -12,6 +12,8 @@ export function getMutable<T extends string>(immutable: T[]) {
   return immutable as Mutable<T[]>
 }
 
+export type Prop<T, K> = K extends keyof T ? T[K] : never
+
 export type ValueOf<T> = T[keyof T]
 
 export type SomeRequired<T, K extends keyof T> = T & { [k in K]-?: T[k] }

--- a/packages/core/src/utils/extend.ts
+++ b/packages/core/src/utils/extend.ts
@@ -1,8 +1,8 @@
-import type { ExtendedTypes } from '../defineConfig'
+import type { StrictExtendedTypes, NarrowExtendedTypes } from '../defineConfig'
 
 declare global {
   // eslint-disable-next-line no-var
-  var __graphqlGeneExtendedTypes: ExtendedTypes | undefined
+  var __graphqlGeneExtendedTypes: StrictExtendedTypes | undefined
 }
 
 export function getGloballyExtendedTypes() {
@@ -11,7 +11,9 @@ export function getGloballyExtendedTypes() {
   return globalThis.__graphqlGeneExtendedTypes
 }
 
-export function extendTypes(types: ExtendedTypes) {
+export function extendTypes<T extends Record<string, Record<string, object>>>(
+  types: NarrowExtendedTypes<T>
+) {
   const globalTypes = getGloballyExtendedTypes()
 
   Object.entries(types).forEach(([graphqlType, fieldConfigs]) => {

--- a/packages/core/src/utils/extend.ts
+++ b/packages/core/src/utils/extend.ts
@@ -1,3 +1,4 @@
+import { isObject } from '.'
 import type {
   StrictExtendedTypes,
   NarrowExtendedTypes,
@@ -32,6 +33,9 @@ export function extendTypes<
   const globalTypes = getGloballyExtendedTypes()
 
   Object.entries(types).forEach(([graphqlType, fieldConfigs]) => {
+    if (!isObject(fieldConfigs)) {
+      throw new Error(`Provided field config for type "${graphqlType}" must be an object.`)
+    }
     const type = graphqlType as 'Query'
     globalTypes[type] = globalTypes[type] || {}
     globalTypes[type] = { ...globalTypes[type], ...fieldConfigs }

--- a/packages/core/src/utils/extend.ts
+++ b/packages/core/src/utils/extend.ts
@@ -1,4 +1,9 @@
-import type { StrictExtendedTypes, NarrowExtendedTypes } from '../defineConfig'
+import type {
+  StrictExtendedTypes,
+  NarrowExtendedTypes,
+  StrictArgsDefinition,
+} from '../defineConfig'
+import type { GraphqlReturnTypes, ValidGraphqlType } from '../types'
 
 declare global {
   // eslint-disable-next-line no-var
@@ -11,9 +16,19 @@ export function getGloballyExtendedTypes() {
   return globalThis.__graphqlGeneExtendedTypes
 }
 
-export function extendTypes<T extends Record<string, Record<string, object>>>(
-  types: NarrowExtendedTypes<T>
-) {
+export function extendTypes<
+  T extends {
+    [TypeName in keyof T]: {
+      [Field in keyof T[TypeName]]: {
+        [K in keyof T[TypeName][Field]]: K extends 'returnType'
+          ? GraphqlReturnTypes<ValidGraphqlType>
+          : K extends 'args'
+            ? StrictArgsDefinition
+            : T[TypeName][Field][K]
+      }
+    }
+  },
+>(types: NarrowExtendedTypes<T>) {
   const globalTypes = getGloballyExtendedTypes()
 
   Object.entries(types).forEach(([graphqlType, fieldConfigs]) => {

--- a/packages/dev-playground/package.json
+++ b/packages/dev-playground/package.json
@@ -7,7 +7,8 @@
     "dev": "NODE_ENV=development concurrently --kill-others -p=none \"pnpm build --watch --emptyOutDir=false\" \"nodemon --inspect=8805 --watch ./src/schema.gql --watch ./dist --watch ../core/dist -e js dist/server\"",
     "console": "node dist/console.js",
     "build": "NODE_ENV=${NODE_ENV:-development} vite build",
-    "start": "node dist/server"
+    "start": "node dist/server",
+    "types:check": "tsc --noEmit"
   },
   "devDependencies": {
     "@faker-js/faker": "^9.3.0",

--- a/packages/dev-playground/src/constants.ts
+++ b/packages/dev-playground/src/constants.ts
@@ -4,4 +4,4 @@ import { fileURLToPath } from 'node:url'
 export const ABSOLUTE_ROOT_DIR = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..')
 export const ABSOLUTE_SRC_DIR = path.join(ABSOLUTE_ROOT_DIR, 'src')
 
-export const GRAPHQL_YOGA_PORT = 4455
+export const GRAPHQL_YOGA_PORT = 4466

--- a/packages/dev-playground/src/models/Order/Order.model.ts
+++ b/packages/dev-playground/src/models/Order/Order.model.ts
@@ -8,7 +8,7 @@ import {
   Model,
   Table,
 } from 'sequelize-typescript'
-import { extendTypes, defineGraphqlGeneConfig } from 'graphql-gene'
+import { extendTypes, defineGraphqlGeneConfig, defineField } from 'graphql-gene'
 import { OrderItem } from '../OrderItem/OrderItem.model'
 import { Address } from '../Address/Address.model'
 
@@ -52,5 +52,27 @@ extendTypes({
       resolver: 'default',
       returnType: 'Order',
     },
+  },
+
+  Order: {
+    fieldAddedWithExtendTypes: {
+      args: { prefix: 'String!', separator: 'String!' },
+      /**
+       * Make sure that we can use data from the `source` and `args` options. This is tested
+       * in the integration tests, but will also go through the type checks.
+       */
+      resolver: ({ source, args }) => `${args.prefix}${args.separator}${source.status}`,
+      returnType: 'String!',
+    },
+
+    /**
+     * This is to ensure that using the deprecated method `defineField` is still valid. It will
+     * be raised by the "types:check" script in the CI if it starts throwing Typescript errors.
+     */
+    hasUsedDeprecatedDefineField: defineField({
+      args: { input: 'String!' },
+      resolver: ({ source, args }) => !!(source?.status && args.input),
+      returnType: 'Boolean!',
+    }),
   },
 })

--- a/packages/dev-playground/src/test/integration.spec.ts
+++ b/packages/dev-playground/src/test/integration.spec.ts
@@ -1,11 +1,10 @@
-import { vi, describe, it, expect } from 'vitest'
 import type { ExecutionResult } from 'graphql'
 import { createYoga } from 'graphql-yoga'
 import { buildHTTPExecutor } from '@graphql-tools/executor-http'
 import { sequelize } from '../models/sequelize'
 import { useMetaPlugin } from '../plugins/useMetaPlugin'
-import { getFixtureQuery } from '../utils/graphql'
-import { schema } from './schema'
+import { schema } from '../server/schema'
+import { getFixtureQuery } from './utils'
 
 await sequelize.authenticate()
 
@@ -23,7 +22,7 @@ describe('integration', () => {
   describe('when sending query with filters for default resolver returning single entry', async () => {
     consoleErrorSpy.mockClear()
     const result = await execute({
-      document: getFixtureQuery('queries/mostRecentOrderWithStatus.gql'),
+      document: getFixtureQuery('queries/mostRecentOrderByStatus.gql'),
       variables: { status: 'paid' },
     })
 
@@ -32,6 +31,8 @@ describe('integration', () => {
         id: 160,
         status: 'paid',
         updatedAt: '2024-11-27T07:43:13.000Z',
+        fieldAddedWithExtendTypes: 'status: paid',
+
         items: [
           {
             id: 402,

--- a/packages/dev-playground/src/test/queries/mostRecentOrderByStatus.gql
+++ b/packages/dev-playground/src/test/queries/mostRecentOrderByStatus.gql
@@ -1,8 +1,9 @@
-query mostRecentOrderWithStatus($status: String!) {
+query mostRecentOrderByStatus($status: String!) {
   order(where: { status: { eq: $status } }, order: [updatedAt_DESC]) {
     id
     status
     updatedAt
+    fieldAddedWithExtendTypes(prefix: "status", separator: ": ")
 
     items {
       id

--- a/packages/dev-playground/src/test/utils.ts
+++ b/packages/dev-playground/src/test/utils.ts
@@ -4,5 +4,5 @@ import { parse } from 'graphql'
 import { ABSOLUTE_SRC_DIR } from '../constants'
 
 export function getFixtureQuery(filePath: string) {
-  return parse(fs.readFileSync(path.resolve(ABSOLUTE_SRC_DIR, `./${filePath}`), 'utf8'))
+  return parse(fs.readFileSync(path.resolve(ABSOLUTE_SRC_DIR, `./test/${filePath}`), 'utf8'))
 }

--- a/packages/dev-playground/src/types/graphql-gene.d.ts
+++ b/packages/dev-playground/src/types/graphql-gene.d.ts
@@ -1,5 +1,5 @@
 import type { YogaInitialContext } from 'graphql-yoga'
-import type { GeneTypesToTypescript } from '../../../core/src'
+import type { GeneTypesToTypescript } from 'graphql-gene'
 import * as graphqlTypes from '../models/graphqlTypes'
 import type { FastifyContext } from '../server/types'
 

--- a/packages/dev-playground/tsconfig.json
+++ b/packages/dev-playground/tsconfig.json
@@ -2,9 +2,6 @@
   "extends": "../../tsconfig.json",
 
   "compilerOptions": {
-    "paths": {
-      "graphql-gene": ["../core/src/index.ts"]
-    },
     "noEmit": true,
 
     /**

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -19,6 +19,7 @@ export default defineConfig({
   },
 
   test: {
+    globals: true,
     include: ['**/*.spec.ts'],
     globalSetup: 'vitest.setup.ts',
 
@@ -28,10 +29,10 @@ export default defineConfig({
       include: ['packages/core/src/**', 'packages/plugin-sequelize/src/**'],
 
       thresholds: {
-        statements: 49,
-        branches: 41,
-        functions: 47,
-        lines: 50,
+        lines: 51,
+        functions: 48,
+        statements: 50,
+        branches: 43,
       },
     },
   },


### PR DESCRIPTION
Improve inferring types for the `resolver` parameters when adding GraphQL fields using `extendTypes`.

#### Before

```ts
extendTypes({
  Order: {
    formattedStatus: defineField({
      args: { extra: 'String' },

      resolver: ({ source, args }) => {
        return `Order status: ${source?.status}${args.extra ?? ''}`
      },
      returnType: 'String!',
    }),
  },
})
```

#### Now

```ts
extendTypes({
  Order: {
    formattedStatus: {
      args: { extra: 'String' },

      resolver: ({ source, args }) => {
        return `Order status: ${source.status}${args.extra ?? ''}`
      },
      returnType: 'String!',
    },
  },
})
```

So using `defineField` is not necessary anymore (is now marked as `@deprecated`). Also noticed that `source?.status` is now `source.status` which is the biggest improvement: the `source` parameter is now inferred from the parent type so the resolver is now aware that the `source` should be of type `Order`. For `Query` and `Mutation`, the `source` will be undefined.

I also added integration tests for those fields added using `extendTypes`. Moreover, to make sure we keep the accuracy of the inferred types, a `types:check` script was added to the `dev-playground` package.