### PR TITLE
feat: add "findOptions" option to field config

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -61,12 +61,14 @@
     }
   },
   "peerDependencies": {
-    "graphql": "16.x"
+    "graphql": "16.x",
+    "graphql-lookahead": "^1.2.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.8",
     "dev-utils": "workspace:*",
     "graphql": "^16.9.0",
+    "graphql-lookahead": "^1.2.1",
     "typescript": "^5.7.2",
     "vite": "^6.0.1"
   },

--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -1,6 +1,8 @@
 import type { GraphQLFieldResolver } from 'graphql'
+import type { UntilHandlerDetails } from 'graphql-lookahead'
 import type { GeneContext } from 'graphql-gene/context'
 import type {
+  FindOptionsState,
   GraphQLFieldName,
   GraphqlReturnTypes,
   GraphqlToTypescript,
@@ -88,7 +90,9 @@ export type ExtendedTypeField<T, TypeName> = {
         ? T[K] extends StrictArgsDefinition
           ? Narrow<T[K]>
           : never
-        : Narrow<T[K]>
+        : K extends 'findOptions'
+          ? FindOptionsState<TypeName, T[K]>
+          : Narrow<T[K]>
 }
 
 export type StrictExtendedTypes<
@@ -163,8 +167,9 @@ export type GeneTypeConfig<
 > = {
   directives?: GeneDirectiveConfig[]
   args?: TArgDefs extends undefined ? undefined : TArgDefs
-  returnType: TReturnType extends unknown ? GraphqlReturnTypes<ValidGraphqlType> : TReturnType
   resolver?: GeneResolverOption<TSource, TContext, TArgDefs, TReturnType>
+  returnType: TReturnType extends unknown ? GraphqlReturnTypes<ValidGraphqlType> : TReturnType
+  findOptions?: (details: UntilHandlerDetails<object>) => void
 }
 
 export type FieldConfig<

--- a/packages/core/src/types/graphqlToTypescript.ts
+++ b/packages/core/src/types/graphqlToTypescript.ts
@@ -1,3 +1,4 @@
+import type { UntilHandlerDetails } from 'graphql-lookahead'
 import type { GenePluginSettings } from 'graphql-gene/plugin-settings'
 import type { GraphqlTypes } from './graphql'
 import type { NeverToUnknown, PossiblyUndefinedToPartial, ValueOf } from './typeUtils'
@@ -106,3 +107,15 @@ type HasPluginMatchingOrNever<M> = {
 }[keyof GenePluginSettings<M>]
 
 export type HasPluginMatching<M> = HasPluginMatchingOrNever<M> extends never ? false : true
+
+export type FindOptionsStateByModel<M, TFallback = never> = {
+  [k in keyof GenePluginSettings<M>]: GenePluginSettings<M>[k]['isMatching'] extends true
+    ? GenePluginSettings<M>[k]['findOptionsState']
+    : TFallback
+}[keyof GenePluginSettings<M>]
+
+type UntilHandler<TState> = (details: UntilHandlerDetails<TState>) => void
+
+export type FindOptionsState<TTypeName, TFallback = never> = TTypeName extends keyof GraphqlTypes
+  ? UntilHandler<FindOptionsStateByModel<GraphqlTypes[TTypeName], TFallback>>
+  : TFallback

--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -6,7 +6,11 @@ import type { GraphQLVarType, ResolversOrScalars } from './graphql'
 import type { GraphqlToTypescript } from './graphqlToTypescript'
 
 export type PluginSettings<
-  T extends { isMatching: boolean; fieldName: TField extends string ? string : never },
+  T extends {
+    isMatching: boolean
+    fieldName: TField extends string ? string : never
+    findOptionsState: object
+  },
   TField extends string | number | symbol = string,
 > = T
 

--- a/packages/core/src/types/typeUtils.spec.ts
+++ b/packages/core/src/types/typeUtils.spec.ts
@@ -1,0 +1,10 @@
+import { getMutable } from './typeUtils'
+
+const IMMUTABLE = ['a', 'b'] as const
+
+describe('#getMutable', () => {
+  it('returns the array provided, but without readonly', () => {
+    const mutable = getMutable(IMMUTABLE)
+    expect(mutable).toEqual(IMMUTABLE)
+  })
+})

--- a/packages/core/src/types/typeUtils.ts
+++ b/packages/core/src/types/typeUtils.ts
@@ -8,7 +8,7 @@ export type Mutable<Immutable> = {
   -readonly [K in keyof Immutable]: Immutable[K]
 }
 
-export function getMutable<T extends string>(immutable: T[]) {
+export function getMutable<T extends string>(immutable: T[] | readonly T[]) {
   return immutable as Mutable<T[]>
 }
 

--- a/packages/core/src/utils/extend.ts
+++ b/packages/core/src/utils/extend.ts
@@ -3,6 +3,7 @@ import type {
   StrictExtendedTypes,
   NarrowExtendedTypes,
   StrictArgsDefinition,
+  GeneDirectiveConfig,
 } from '../defineConfig'
 import type { GraphqlReturnTypes, ValidGraphqlType } from '../types'
 
@@ -25,7 +26,9 @@ export function extendTypes<
           ? GraphqlReturnTypes<ValidGraphqlType>
           : K extends 'args'
             ? StrictArgsDefinition
-            : T[TypeName][Field][K]
+            : K extends 'directives'
+              ? GeneDirectiveConfig[]
+              : T[TypeName][Field][K]
       }
     }
   },

--- a/packages/core/src/utils/extend.ts
+++ b/packages/core/src/utils/extend.ts
@@ -1,4 +1,3 @@
-import { isObject } from '.'
 import type {
   StrictExtendedTypes,
   NarrowExtendedTypes,
@@ -6,6 +5,7 @@ import type {
   GeneDirectiveConfig,
 } from '../defineConfig'
 import type { GraphqlReturnTypes, ValidGraphqlType } from '../types'
+import { isObject } from '.'
 
 declare global {
   // eslint-disable-next-line no-var

--- a/packages/core/tsconfig.lint.json
+++ b/packages/core/tsconfig.lint.json
@@ -5,5 +5,5 @@
     "noEmit": true
   },
 
-  "exclude": ["**/node_modules", "./dist", "**/*.spec.ts"]
+  "exclude": ["**/node_modules", "./dist"]
 }

--- a/packages/dev-playground/package.json
+++ b/packages/dev-playground/package.json
@@ -4,7 +4,7 @@
   "main": "./dist/index.js",
   "type": "module",
   "scripts": {
-    "dev": "NODE_ENV=development concurrently --kill-others -p=none \"pnpm build --watch --emptyOutDir=false\" \"nodemon --inspect=8805 --watch ./src/schema.gql --watch ./dist --watch ../core/dist -e js dist/server\"",
+    "dev": "NODE_ENV=development concurrently --kill-others -p=none \"pnpm build --watch --emptyOutDir=false\" \"nodemon --inspect=8805 --watch ./src/schema.gql --watch ./dist --watch ../core/dist --watch ../plugin-sequelize/dist -e js dist/server\"",
     "console": "node dist/console.js",
     "build": "NODE_ENV=${NODE_ENV:-development} vite build",
     "start": "node dist/server",

--- a/packages/dev-playground/src/models/Order/Order.model.ts
+++ b/packages/dev-playground/src/models/Order/Order.model.ts
@@ -15,9 +15,9 @@ import {
   defineType,
   defineEnum,
 } from 'graphql-gene'
+import { getQueryIncludeOf } from '@graphql-gene/plugin-sequelize'
 import { OrderItem } from '../OrderItem/OrderItem.model'
 import { Address } from '../Address/Address.model'
-import { getQueryIncludeOf } from '@graphql-gene/plugin-sequelize'
 
 export
 @Table

--- a/packages/dev-playground/src/models/ProductGroup/ProductGroup.model.ts
+++ b/packages/dev-playground/src/models/ProductGroup/ProductGroup.model.ts
@@ -5,10 +5,10 @@ import type {
   InferCreationAttributes,
 } from 'sequelize'
 import { BelongsToMany, Column, DataType, HasMany, Model, Table } from 'sequelize-typescript'
+import { defineGraphqlGeneConfig, extendTypes } from 'graphql-gene'
 import { Product } from '../Product/Product.model'
 import { ProductCategory } from '../ProductCategory/ProductCategory.model'
 import { ProductGroupCategory } from '../ProductGroupCategory/ProductGroupCategory.model'
-import { defineGraphqlGeneConfig, extendTypes } from 'graphql-gene'
 
 export
 @Table
@@ -42,6 +42,11 @@ extendTypes({
       },
       returnType: '[String!]',
 
+      /**
+       * Using `findOptions`, we make sure that the `groupCategories` is included in the
+       * query for `ProductGroup` whenever this field is requested so we can access it within
+       * the resolver.
+       */
       findOptions({ state }) {
         state.include = state.include || []
         state.include.push({

--- a/packages/dev-playground/src/models/graphqlTypes.ts
+++ b/packages/dev-playground/src/models/graphqlTypes.ts
@@ -1,1 +1,8 @@
 export * from './models'
+
+export {
+  UpdateOrderStatusOutput,
+  OrderStatusEnum,
+  MessageOutput,
+  MessageTypeEnum,
+} from './Order/Order.model'

--- a/packages/dev-playground/src/test/integration.spec.ts
+++ b/packages/dev-playground/src/test/integration.spec.ts
@@ -42,13 +42,8 @@ describe('integration', () => {
               name: 'TrailMaster - Storm Gray',
               color: 'Storm Gray',
               group: {
-                product: { id: 74 },
-                groupCategories: [
-                  { category: { name: 'shoes' } },
-                  { category: { name: 'trail' } },
-                  { category: { name: 'competition' } },
-                  { category: { name: 'support' } },
-                ],
+                products: [{ id: 70 }, { id: 71 }, { id: 72 }, { id: 73 }, { id: 74 }],
+                categories: ['shoes', 'trail', 'competition', 'support'],
               },
             },
           },
@@ -60,17 +55,52 @@ describe('integration', () => {
               name: 'Impulse - Thunder Gray',
               color: 'Thunder Gray',
               group: {
-                product: { id: 225 },
-                groupCategories: [
-                  { category: { name: 'trail' } },
-                  { category: { name: 'apparel' } },
-                  { category: { name: 'top' } },
-                  { category: { name: 'light' } },
-                ],
+                products: [{ id: 224 }, { id: 225 }, { id: 226 }, { id: 227 }, { id: 228 }],
+                categories: ['trail', 'apparel', 'top', 'light'],
               },
             },
           },
         ],
+      })
+    })
+  })
+
+  describe('when sending mutation returning mutated object using "getQueryIncludeOf"', async () => {
+    describe('when providing valid "id"', async () => {
+      consoleErrorSpy.mockClear()
+      const result = await execute({
+        document: getFixtureQuery('mutations/updateOrderStatus.gql'),
+        variables: { id: '26', status: 'payment' },
+      })
+
+      it('returns the expected data', () => {
+        expect(result.data.updateOrderStatus).toEqual({
+          message: { type: 'success', text: 'Status updated successfully.' },
+          order: {
+            id: 26,
+            status: 'payment',
+            items: [
+              { product: { name: 'Nexus - Uranium Gray' } },
+              { product: { name: 'NatureTrek - Deep Indigo' } },
+              { product: { name: 'NatureTrek - Moss Green' } },
+            ],
+          },
+        })
+      })
+    })
+
+    describe('when providing invalid "id"', async () => {
+      consoleErrorSpy.mockClear()
+      const result = await execute({
+        document: getFixtureQuery('mutations/updateOrderStatus.gql'),
+        variables: { id: 'invalid', status: 'paid' },
+      })
+
+      it('returns the expected data', () => {
+        expect(result.data.updateOrderStatus).toEqual({
+          message: { type: 'error', text: 'Status could not be updated.' },
+          order: null,
+        })
       })
     })
   })

--- a/packages/dev-playground/src/test/mutations/updateOrderStatus.gql
+++ b/packages/dev-playground/src/test/mutations/updateOrderStatus.gql
@@ -1,0 +1,18 @@
+mutation updateOrderStatus($id: String!, $status: OrderStatusEnum!) {
+  updateOrderStatus(id: $id, status: $status) {
+    message {
+      type
+      text
+    }
+    order {
+      id
+      status
+
+      items {
+        product {
+          name
+        }
+      }
+    }
+  }
+}

--- a/packages/dev-playground/src/test/queries/mostRecentOrderByStatus.gql
+++ b/packages/dev-playground/src/test/queries/mostRecentOrderByStatus.gql
@@ -14,14 +14,10 @@ query mostRecentOrderByStatus($status: String!) {
         color
 
         group {
-          product {
+          products {
             id
           }
-          groupCategories {
-            category {
-              name
-            }
-          }
+          categories
         }
       }
     }

--- a/packages/plugin-sequelize/package.json
+++ b/packages/plugin-sequelize/package.json
@@ -56,7 +56,7 @@
     "sequelize-typescript": "2.x"
   },
   "dependencies": {
-    "graphql-lookahead": "^1.2.0"
+    "graphql-lookahead": "^1.3.0-beta.1"
   },
   "devDependencies": {
     "@types/node": "^20.17.8",

--- a/packages/plugin-sequelize/src/plugin.ts
+++ b/packages/plugin-sequelize/src/plugin.ts
@@ -4,6 +4,7 @@ import { Model } from 'sequelize-typescript'
 import { defaultResolver } from './defaultResolver'
 import { populateTypeDefs } from './populateTypeDefs'
 import type { GeneModel } from './constants'
+import type { DefaultResolverIncludeOptions } from './types'
 
 declare module 'graphql-gene/plugin-settings' {
   export interface GenePluginSettings<M> {
@@ -14,6 +15,7 @@ declare module 'graphql-gene/plugin-settings' {
           ? keyof InferAttributes<PrototypeOrNot<M>>
           : 'id'
         : 'id'
+      findOptionsState: DefaultResolverIncludeOptions
     }>
   }
 }

--- a/packages/plugin-sequelize/src/types.ts
+++ b/packages/plugin-sequelize/src/types.ts
@@ -1,8 +1,20 @@
 import type { AnyObject } from 'graphql-gene'
-import type { WhereAttributeHash } from 'sequelize'
+import type { IncludeOptions, WhereAttributeHash } from 'sequelize'
 
 export type GeneSequelizeWhereOptions = {
   [k in keyof WhereAttributeHash<AnyObject> | symbol]: k extends symbol
     ? WhereAttributeHash<AnyObject>[]
     : WhereAttributeHash<AnyObject>[k extends symbol ? never : k]
+}
+
+export type DefaultResolverIncludeOptions = Pick<
+  IncludeOptions,
+  'where' | 'order' | 'association' | 'limit'
+> & {
+  include?: DefaultResolverIncludeOptions[]
+  /**
+   * "offset" is missing in IncludeOptions
+   * @see https://github.com/sequelize/sequelize/issues/12969
+   */
+  offset?: number
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -74,6 +74,9 @@ importers:
       graphql:
         specifier: ^16.9.0
         version: 16.9.0
+      graphql-lookahead:
+        specifier: ^1.2.1
+        version: 1.2.2(graphql@16.9.0)
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -157,8 +160,8 @@ importers:
   packages/plugin-sequelize:
     dependencies:
       graphql-lookahead:
-        specifier: ^1.2.0
-        version: 1.2.0(graphql@16.9.0)
+        specifier: ^1.3.0-beta.1
+        version: 1.3.0-beta.1(graphql@16.9.0)
     devDependencies:
       '@types/node':
         specifier: ^20.17.8
@@ -2126,8 +2129,14 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphql-lookahead@1.2.0:
-    resolution: {integrity: sha512-RwLZFeRJT/7fc/LxJOK6VNv+V84ciAyWCNqvwMPGaqE99lu7N+tC0w/aM8+eiHu7V2rOwEG+we7M6+msBQVy4g==}
+  graphql-lookahead@1.2.2:
+    resolution: {integrity: sha512-LPadjCwh+fidzhHCQUkTxyNEioMoKtlXH07Y3Yn+GPH73ADwCeVaV5HwRxarIC7014ZQA2Es/7WlJbmocDLHDg==}
+    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
+    peerDependencies:
+      graphql: 16.x
+
+  graphql-lookahead@1.3.0-beta.1:
+    resolution: {integrity: sha512-ES9U2B7Fj+jRxMyhBnfo85UHvR0ye9+YcUn+4Il8It0EyhEG3vDGO6wzgtP24Kd8IA+raiqMILBDiwiZrPlp9w==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     peerDependencies:
       graphql: 16.x
@@ -6073,7 +6082,11 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-lookahead@1.2.0(graphql@16.9.0):
+  graphql-lookahead@1.2.2(graphql@16.9.0):
+    dependencies:
+      graphql: 16.9.0
+
+  graphql-lookahead@1.3.0-beta.1(graphql@16.9.0):
     dependencies:
       graphql: 16.9.0
 


### PR DESCRIPTION
With the new `findOptions` hook, you can add include options to the query whenever a specific field is requested so you can be sure the date will be accessible from the resolver:

https://github.com/accesimpot/graphql-gene/blob/65edffcdfc339e6186d9e383013fb6c44eaabc40/packages/dev-playground/src/models/ProductGroup/ProductGroup.model.ts#L37-L59