### PR TITLE
fix: geneConfig directives not registering anymore

### DIFF
--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -125,7 +125,7 @@ export interface GeneConfig<
   /** Directives to apply at the type level (also possible at the field level). */
   directives?: GeneDirectiveConfig<
     Record<string, string | number | boolean | null> | undefined,
-    PrototypeOrNot<M>
+    TSource extends M ? PrototypeOrNot<M> : TSource
   >[]
 
   /**
@@ -323,10 +323,13 @@ export function defineDirective<
   TSource = Record<string, unknown> | undefined,
   TContext = GeneContext,
   TArgs = Record<string, unknown> | undefined,
->(
-  directive: GeneDirective<TDirectiveArgs, TSource, TContext, TArgs>
-): GeneDirective<TDirectiveArgs, TSource, TContext, TArgs> {
-  return directive
+>(directive: GeneDirective<TDirectiveArgs, TSource, TContext, TArgs>) {
+  return directive as GeneDirective<
+    TDirectiveArgs,
+    Record<string, unknown> | undefined,
+    TContext,
+    TArgs
+  >
 }
 
 /**

--- a/packages/core/src/resolvers.ts
+++ b/packages/core/src/resolvers.ts
@@ -1,5 +1,10 @@
 import { defaultFieldResolver, GraphQLSchema } from 'graphql'
-import type { GeneConfig, GeneDefaultResolverArgs, ExtendedTypes } from './defineConfig'
+import type {
+  GeneConfig,
+  GeneDefaultResolverArgs,
+  ExtendedTypes,
+  GeneTypeConfig,
+} from './defineConfig'
 import {
   lookDeepInSchema,
   isUsingDefaultResolver,
@@ -88,13 +93,15 @@ function defineResolvers<SchemaTypes extends AnyObject>(options: {
 
       if (!hasTypeDirectives && !isFieldInTypeConfig()) return
 
+      let normalizedConfig: GeneTypeConfig | undefined
       const currentTypeConfig = typeConfig[parentType as keyof typeof typeConfig]
-      if (!currentTypeConfig || isArrayFieldConfig(currentTypeConfig)) return
 
-      const config = (
-        currentTypeConfig as Record<string, Parameters<typeof normalizeFieldConfig>[0]>
-      )[field]
-      const normalizedConfig = config ? normalizeFieldConfig(config) : undefined
+      if (currentTypeConfig && !isArrayFieldConfig(currentTypeConfig)) {
+        const config = (
+          currentTypeConfig as Record<string, Parameters<typeof normalizeFieldConfig>[0]>
+        )[field]
+        normalizedConfig = config ? normalizeFieldConfig(config) : undefined
+      }
 
       const returnTypeName = getReturnTypeName(
         normalizedConfig?.returnType || options.typeDefLines[parentType]?.lines[field]?.typeDef

--- a/packages/dev-playground/src/models/Inventory/Inventory.model.ts
+++ b/packages/dev-playground/src/models/Inventory/Inventory.model.ts
@@ -7,6 +7,8 @@ import {
   Model,
   Table,
 } from 'sequelize-typescript'
+import { defineGraphqlGeneConfig } from 'graphql-gene'
+import { authorizationDirective } from '../../directives/authorization.directive'
 import { ProductVariant } from '../ProductVariant/ProductVariant.model'
 import type { CreationOptional, InferAttributes, InferCreationAttributes } from 'sequelize'
 
@@ -23,4 +25,8 @@ class Inventory extends Model<InferAttributes<Inventory>, InferCreationAttribute
 
   @BelongsTo(() => ProductVariant)
   declare variant: CreationOptional<ProductVariant | null>
+
+  static readonly geneConfig = defineGraphqlGeneConfig(Inventory, {
+    directives: [authorizationDirective()],
+  })
 }

--- a/packages/dev-playground/src/test/queries/orderWithInventory.gql
+++ b/packages/dev-playground/src/test/queries/orderWithInventory.gql
@@ -1,0 +1,16 @@
+query orderWithInventory($id: String!) {
+  order(id: $id) {
+    items {
+      quantity
+
+      product {
+        name
+        variants {
+          inventory {
+            stock
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
https://github.com/accesimpot/graphql-gene/pull/72 fixed the directives that were sometimes not registered at the field level, but it broke registering the ones at the type level.

This PR fixes it and adds the missing tests (we now have integration tests for both directives at the field and type level).