### PR TITLE
feat: provide filter function in directive handler arg

### DIFF
--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -293,6 +293,7 @@ export type GeneDirectiveHandler<
   context: Parameters<GraphQLFieldResolver<TSource, TContext, TArgs, TResult>>[2]
   info: Parameters<GraphQLFieldResolver<TSource, TContext, TArgs, TResult>>[3]
   field: string
+  filter: <TValue>(callback: (value: TValue) => unknown) => void
   resolve: () => Promise<TResult> | TResult
 }) => Promise<void> | void
 

--- a/packages/core/src/resolvers.ts
+++ b/packages/core/src/resolvers.ts
@@ -169,6 +169,7 @@ function defineResolvers<SchemaTypes extends AnyObject>(options: {
               context,
               info,
               field,
+              filter: getFilterFunction({ source, field }),
               resolve,
             })
             if (!hasCalledResolve) await resolve()
@@ -180,4 +181,18 @@ function defineResolvers<SchemaTypes extends AnyObject>(options: {
     },
   })
   return options.schema
+}
+
+function getFilterFunction<TSource>(options: { source: TSource; field: string }) {
+  const { field } = options
+
+  return <TValue>(callback: (value: TValue) => unknown) => {
+    const source = options.source as unknown as Record<string, TValue | TValue[] | undefined | null>
+
+    if (Array.isArray(source[field])) {
+      source[field] = source[field].filter(callback)
+    } else {
+      if (source[field] && !callback(source[field])) source[field] = null
+    }
+  }
 }

--- a/packages/dev-playground/src/models/ProductVariant/ProductVariant.model.ts
+++ b/packages/dev-playground/src/models/ProductVariant/ProductVariant.model.ts
@@ -1,7 +1,9 @@
+import type { InferAttributes, InferCreationAttributes } from 'sequelize'
 import { BelongsTo, Column, DataType, ForeignKey, HasOne, Model, Table } from 'sequelize-typescript'
+import { defineGraphqlGeneConfig } from 'graphql-gene'
 import { Product } from '../Product/Product.model'
 import { Inventory } from '../Inventory/Inventory.model'
-import type { InferAttributes, InferCreationAttributes } from 'sequelize'
+import { filterBySizeDirective } from './filterBySize.directive'
 
 export
 @Table
@@ -21,4 +23,8 @@ class ProductVariant extends Model<
 
   @BelongsTo(() => Product)
   declare product: Product | null
+
+  static readonly geneConfig = defineGraphqlGeneConfig(ProductVariant, {
+    directives: [filterBySizeDirective()],
+  })
 }

--- a/packages/dev-playground/src/models/ProductVariant/filterBySize.directive.ts
+++ b/packages/dev-playground/src/models/ProductVariant/filterBySize.directive.ts
@@ -1,0 +1,16 @@
+import { defineDirective } from 'graphql-gene'
+import type { ProductVariant } from './ProductVariant.model'
+
+export const filterBySizeDirective = defineDirective(args => ({
+  name: 'filterBySize',
+  args,
+
+  async handler({ context, filter }) {
+    // For testing purposes
+    const isActive = context.request.headers.get('x-test-size-filter-active') === 'true'
+    if (!isActive) return
+
+    // TODO: Improve by inferring the type from defineDirective
+    filter((variant: ProductVariant) => variant.size !== 'XLL')
+  },
+}))

--- a/packages/dev-playground/src/test/queries/orderById.gql
+++ b/packages/dev-playground/src/test/queries/orderById.gql
@@ -14,6 +14,10 @@ query orderById($id: String!) {
         group {
           categories
         }
+
+        variants {
+          size
+        }
       }
     }
   }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -29,9 +29,9 @@ export default defineConfig({
       include: ['packages/core/src/**', 'packages/plugin-sequelize/src/**'],
 
       thresholds: {
-        lines: 56,
-        functions: 54,
-        statements: 55,
+        lines: 57,
+        functions: 55,
+        statements: 56,
         branches: 48,
       },
     },


### PR DESCRIPTION
Provide a `filter` function in directives. It will filter the result at the type level no matter if it is an array or a single entry.

https://github.com/accesimpot/graphql-gene/blob/c0d271759172cf3b3e3ed2ff5412ceeb21f1f3cf/packages/dev-playground/src/models/ProductVariant/filterBySize.directive.ts#L4-L16