### PR TITLE
fix: providing explicit type to defineDirective

### DIFF
--- a/packages/core/src/defineConfig.ts
+++ b/packages/core/src/defineConfig.ts
@@ -263,7 +263,9 @@ export type GeneDirective<
   TSource = Record<string, unknown> | undefined,
   TContext = GeneContext,
   TArgs = Record<string, unknown> | undefined,
-> = (args?: TDirectiveArgs) => GeneDirectiveConfig<TDirectiveArgs, TSource, TContext, TArgs>
+> = TDirectiveArgs extends undefined
+  ? (args?: TDirectiveArgs) => GeneDirectiveConfig<TDirectiveArgs, TSource, TContext, TArgs>
+  : (args: TDirectiveArgs) => GeneDirectiveConfig<TDirectiveArgs, TSource, TContext, TArgs>
 
 export type GeneDirectiveConfig<
   TDirectiveArgs = Record<string, string | number | boolean | null> | undefined,

--- a/packages/dev-playground/src/models/ProductVariant/filterBySize.directive.ts
+++ b/packages/dev-playground/src/models/ProductVariant/filterBySize.directive.ts
@@ -1,9 +1,8 @@
 import { defineDirective } from 'graphql-gene'
 import type { ProductVariant } from './ProductVariant.model'
 
-export const filterBySizeDirective = defineDirective(args => ({
+export const filterBySizeDirective = defineDirective(() => ({
   name: 'filterBySize',
-  args,
 
   async handler({ context, filter }) {
     // For testing purposes


### PR DESCRIPTION
There was a type error when providing an explicit type to `defineDirective` because `args` was optional, therefore ` | undefined` which didn't match the provided type.

```ts
export const userAuthDirective = defineDirective<{ role: `${ADMIN_ROLES}` | null }>(args => ({
  name: 'userAuth',
  args, // <----- There was a type error here

  async handler({ context, info }) {
    // ...
```