### PR TITLE
fix: passing empty array as directive argument

### DIFF
--- a/packages/core/src/types/plugin.ts
+++ b/packages/core/src/types/plugin.ts
@@ -16,7 +16,7 @@ export type PluginSettings<
 
 export type GraphQLTypeName = string
 export type GraphQLFieldName = string
-export type ArgsDef = Record<string, Set<string | null>>
+export type ArgsDef = Record<string, Set<string | string[] | null>>
 
 export type FieldLines = Record<
   GraphQLFieldName,

--- a/packages/dev-playground/src/models/Product/Product.model.ts
+++ b/packages/dev-playground/src/models/Product/Product.model.ts
@@ -13,6 +13,7 @@ import { extendTypes } from 'graphql-gene'
 import { authorizationDirective } from '../../directives/authorization.directive'
 import { ProductGroup } from '../ProductGroup/ProductGroup.model'
 import { ProductVariant } from '../ProductVariant/ProductVariant.model'
+import { sanitizeColorDirective } from './sanitizeColor.directive'
 
 export
 @Table
@@ -42,6 +43,11 @@ extendTypes({
   Product: {
     isPublished: {
       directives: [authorizationDirective()],
+    },
+
+    color: {
+      // Test case: ensure that generating the schema won't fail when providing an empty array
+      directives: [sanitizeColorDirective({ exclude: [] })],
     },
   },
 })

--- a/packages/dev-playground/src/models/Product/sanitizeColor.directive.ts
+++ b/packages/dev-playground/src/models/Product/sanitizeColor.directive.ts
@@ -1,0 +1,15 @@
+import { defineDirective } from 'graphql-gene'
+import type { Product } from './Product.model'
+
+export const sanitizeColorDirective = defineDirective<{
+  exclude: ('Gray' | 'White')[]
+}>(args => ({
+  name: 'sanitizeColor',
+  args,
+
+  async handler({ filter }) {
+    filter((color: Product['color']) =>
+      args.exclude.every(excludedColor => !color?.includes(excludedColor))
+    )
+  },
+}))

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -36,7 +36,7 @@ export default defineConfig({
         lines: 83,
         functions: 77,
         statements: 81,
-        branches: 68,
+        branches: 70,
       },
     },
   },


### PR DESCRIPTION
Following https://github.com/accesimpot/graphql-gene/pull/79
Fix passing an empty array as directive argument.