### PR TITLE
fix: custom type with subfields treated as association

### DIFF
--- a/README.md
+++ b/README.md
@@ -380,6 +380,8 @@ import { isEmail } from '../someUtils.ts'
 export
 @Table
 class Prospect extends Model<InferAttributes<Prospect>, InferCreationAttributes<Prospect>> {
+  declare id: CreationOptional<number>
+
   @Unique
   @AllowNull(false)
   @Column(DataType.STRING)
@@ -538,6 +540,7 @@ import { userAuthDirective } from '.userAuthDirective.ts'
 export
 @Table
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+  declare id: CreationOptional<number>
 
   // ...
 

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -380,6 +380,8 @@ import { isEmail } from '../someUtils.ts'
 export
 @Table
 class Prospect extends Model<InferAttributes<Prospect>, InferCreationAttributes<Prospect>> {
+  declare id: CreationOptional<number>
+
   @Unique
   @AllowNull(false)
   @Column(DataType.STRING)
@@ -538,6 +540,7 @@ import { userAuthDirective } from '.userAuthDirective.ts'
 export
 @Table
 class User extends Model<InferAttributes<User>, InferCreationAttributes<User>> {
+  declare id: CreationOptional<number>
 
   // ...
 

--- a/packages/dev-playground/src/models/Inventory/Inventory.model.ts
+++ b/packages/dev-playground/src/models/Inventory/Inventory.model.ts
@@ -15,6 +15,8 @@ import type { CreationOptional, InferAttributes, InferCreationAttributes } from 
 export
 @Table
 class Inventory extends Model<InferAttributes<Inventory>, InferCreationAttributes<Inventory>> {
+  declare id: CreationOptional<number>
+
   @AllowNull(false)
   @Column(DataType.INTEGER)
   declare stock: number

--- a/packages/dev-playground/src/models/Order/Order.model.ts
+++ b/packages/dev-playground/src/models/Order/Order.model.ts
@@ -1,3 +1,4 @@
+import type { CreationOptional, InferAttributes, InferCreationAttributes } from 'sequelize'
 import {
   AllowNull,
   BelongsTo,
@@ -21,7 +22,9 @@ import { Address } from '../Address/Address.model'
 
 export
 @Table
-class Order extends Model {
+class Order extends Model<InferAttributes<Order>, InferCreationAttributes<Order>> {
+  declare id: CreationOptional<number>
+
   @AllowNull(false)
   @Column(DataType.STRING)
   declare status: string

--- a/packages/dev-playground/src/models/Order/Order.model.ts
+++ b/packages/dev-playground/src/models/Order/Order.model.ts
@@ -15,6 +15,7 @@ import {
   defineField,
   defineType,
   defineEnum,
+  defineInput,
 } from 'graphql-gene'
 import { getQueryIncludeOf } from '@graphql-gene/plugin-sequelize'
 import { OrderItem } from '../OrderItem/OrderItem.model'
@@ -70,6 +71,11 @@ export const MessageOutput = defineType({
 
 export const MessageTypeEnum = defineEnum(['info', 'success', 'warning', 'error'])
 
+// Test case: We also support GraphQL inputs
+export const SomeOtherInput = defineInput({
+  status: 'OrderStatusEnum!',
+})
+
 extendTypes({
   Query: {
     order: {
@@ -80,7 +86,7 @@ extendTypes({
 
   Mutation: {
     updateOrderStatus: {
-      args: { id: 'String!', status: 'OrderStatusEnum!' },
+      args: { id: 'String!', status: 'OrderStatusEnum!', someOtherInput: 'SomeOtherInput' },
 
       async resolver({ info, args }) {
         let messageType: (typeof MessageTypeEnum)[number] = 'success'

--- a/packages/dev-playground/src/models/Product/Product.model.ts
+++ b/packages/dev-playground/src/models/Product/Product.model.ts
@@ -8,8 +8,8 @@ import {
   Model,
   Table,
 } from 'sequelize-typescript'
-import type { InferAttributes, InferCreationAttributes } from 'sequelize'
 import { extendTypes } from 'graphql-gene'
+import type { CreationOptional, InferAttributes, InferCreationAttributes } from 'sequelize'
 import { authorizationDirective } from '../../directives/authorization.directive'
 import { ProductGroup } from '../ProductGroup/ProductGroup.model'
 import { ProductVariant } from '../ProductVariant/ProductVariant.model'
@@ -18,6 +18,8 @@ import { sanitizeColorDirective } from './sanitizeColor.directive'
 export
 @Table
 class Product extends Model<InferAttributes<Product>, InferCreationAttributes<Product>> {
+  declare id: CreationOptional<number>
+
   @AllowNull(false)
   @Column(DataType.STRING)
   declare name: string

--- a/packages/dev-playground/src/models/ProductGroup/ProductGroup.model.ts
+++ b/packages/dev-playground/src/models/ProductGroup/ProductGroup.model.ts
@@ -16,6 +16,8 @@ class ProductGroup extends Model<
   InferAttributes<ProductGroup>,
   InferCreationAttributes<ProductGroup>
 > {
+  declare id: CreationOptional<number>
+
   @Column(DataType.STRING)
   declare name: string | null
 

--- a/packages/dev-playground/src/models/ProductVariant/ProductVariant.model.ts
+++ b/packages/dev-playground/src/models/ProductVariant/ProductVariant.model.ts
@@ -1,4 +1,4 @@
-import type { InferAttributes, InferCreationAttributes } from 'sequelize'
+import type { CreationOptional, InferAttributes, InferCreationAttributes } from 'sequelize'
 import { BelongsTo, Column, DataType, ForeignKey, HasOne, Model, Table } from 'sequelize-typescript'
 import { defineGraphqlGeneConfig } from 'graphql-gene'
 import { Product } from '../Product/Product.model'
@@ -35,6 +35,8 @@ class ProductVariant extends Model<
   InferAttributes<ProductVariant>,
   InferCreationAttributes<ProductVariant>
 > {
+  declare id: CreationOptional<number>
+
   @Column(DataType.STRING)
   declare size: `${SHOE_SIZES}` | `${APPAREL_SIZES}` | null
 

--- a/packages/dev-playground/src/models/graphqlTypes.ts
+++ b/packages/dev-playground/src/models/graphqlTypes.ts
@@ -1,5 +1,6 @@
 export * from './models'
 
+export { ProductReviewAverage } from './Product/Product.model'
 export {
   UpdateOrderStatusOutput,
   OrderStatusEnum,

--- a/packages/dev-playground/src/models/graphqlTypes.ts
+++ b/packages/dev-playground/src/models/graphqlTypes.ts
@@ -5,4 +5,5 @@ export {
   OrderStatusEnum,
   MessageOutput,
   MessageTypeEnum,
+  SomeOtherInput,
 } from './Order/Order.model'

--- a/packages/dev-playground/src/test/mutations/updateOrderStatus.gql
+++ b/packages/dev-playground/src/test/mutations/updateOrderStatus.gql
@@ -1,5 +1,5 @@
 mutation updateOrderStatus($id: String!, $status: OrderStatusEnum!) {
-  updateOrderStatus(id: $id, status: $status) {
+  updateOrderStatus(id: $id, status: $status, someOtherInput: { status: $status }) {
     message {
       type
       text

--- a/packages/dev-playground/src/test/queries/orderById.gql
+++ b/packages/dev-playground/src/test/queries/orderById.gql
@@ -18,6 +18,11 @@ query orderById($id: String!) {
         variants {
           size
         }
+
+        reviewAverage {
+          rating
+          total
+        }
       }
     }
   }

--- a/packages/plugin-sequelize/src/populateTypeDefs.ts
+++ b/packages/plugin-sequelize/src/populateTypeDefs.ts
@@ -15,6 +15,7 @@ import {
   JSON_SCALAR,
   SEQUELIZE_TYPE_TO_GRAPHQL,
 } from './constants'
+import { markFieldAsAssociation } from './utils/associationMap'
 
 const BELONGS_TO_MANY = 'BelongsToMany'
 
@@ -118,6 +119,8 @@ function generateAssociationFields(
 
     lines[attributeKey] = { ...getDefaultFieldLinesObject(), ...lines[attributeKey] }
     lines[attributeKey].typeDef = returnType
+
+    markFieldAsAssociation(options.typeName, attributeKey)
 
     if (isList) {
       populateArgsDefForDefaultResolver({

--- a/packages/plugin-sequelize/src/utils/associationMap.ts
+++ b/packages/plugin-sequelize/src/utils/associationMap.ts
@@ -1,0 +1,10 @@
+const ASSOCIATION_FIELD_MAP: { [type: string]: Set<string> } = {}
+
+export function markFieldAsAssociation(type: string, field: string) {
+  ASSOCIATION_FIELD_MAP[type] = ASSOCIATION_FIELD_MAP[type] || new Set([])
+  ASSOCIATION_FIELD_MAP[type].add(field)
+}
+
+export function isMarkedAsAssociation(type: string, field: string): boolean {
+  return type in ASSOCIATION_FIELD_MAP && ASSOCIATION_FIELD_MAP[type].has(field)
+}

--- a/packages/plugin-sequelize/src/utils/public.ts
+++ b/packages/plugin-sequelize/src/utils/public.ts
@@ -14,6 +14,7 @@ import type { OrderItem } from 'sequelize'
 import type { Model } from 'sequelize-typescript'
 import type { DefaultResolverIncludeOptions, GeneSequelizeWhereOptions } from '../types'
 import { populateWhereOptions } from './internal'
+import { isMarkedAsAssociation } from './associationMap'
 
 const QUERY_TYPE = 'Query'
 const MUTATION_TYPE = 'Mutation'
@@ -78,7 +79,9 @@ export function getQueryInclude(info: GraphQLResolveInfo) {
     state: includeOptions,
     until: untilFindOptions,
 
-    next({ state, field, args, isList }) {
+    next({ state, sourceType, field, args, isList }) {
+      if (!isMarkedAsAssociation(sourceType, field)) return {}
+
       const include = getFieldIncludeOptions({ association: field, args, isList })
 
       state.include = state.include || []
@@ -111,7 +114,9 @@ export function getQueryIncludeOf(
       until: untilFindOptions,
       selectionSet: nextSelectionSet,
 
-      next({ state, field, args, isList }) {
+      next({ state, sourceType, field, args, isList }) {
+        if (!isMarkedAsAssociation(sourceType, field)) return {}
+
         const include = getFieldIncludeOptions({ association: field, args, isList })
 
         state.include = state.include || []

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -33,10 +33,10 @@ export default defineConfig({
       include: ['packages/core/src/**', 'packages/plugin-sequelize/src/**'],
 
       thresholds: {
-        lines: 83,
+        lines: 84,
         functions: 77,
-        statements: 81,
-        branches: 70,
+        statements: 82,
+        branches: 71,
       },
     },
   },


### PR DESCRIPTION
There was an issue when a custom type (defined with `defineType`) was part of the fields being looked at within `getQueryInclude`. The custom type was adding `include: [{ association: 'reviewAverage' }]` making the query fail because `reviewAverage` is not an association in Sequelize.

This PR fixes the issue by marking fields as association when generating the schema so we can check if a field is an association within `getQueryInclude`.

Also add the use of a GraphQL input in the playground (integration tests) to ensure the schema generation is successful when it has at least one input.