### PR TITLE
chore(deps): bump graphql-lookhead from 1.3.0-beta.2 to 1.3.0

### DIFF
--- a/packages/plugin-sequelize/package.json
+++ b/packages/plugin-sequelize/package.json
@@ -56,7 +56,7 @@
     "sequelize-typescript": "2.x"
   },
   "dependencies": {
-    "graphql-lookahead": "^1.3.0-beta.2"
+    "graphql-lookahead": "^1.3.0"
   },
   "devDependencies": {
     "@types/node": "^20.17.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -163,8 +163,8 @@ importers:
   packages/plugin-sequelize:
     dependencies:
       graphql-lookahead:
-        specifier: ^1.3.0-beta.2
-        version: 1.3.0-beta.2(graphql@16.9.0)
+        specifier: ^1.3.0
+        version: 1.3.0(graphql@16.9.0)
     devDependencies:
       '@types/node':
         specifier: ^20.17.8
@@ -2197,8 +2197,8 @@ packages:
     peerDependencies:
       graphql: 16.x
 
-  graphql-lookahead@1.3.0-beta.2:
-    resolution: {integrity: sha512-OhCj28YvdeCrx86hf73Y9RxcmG2oTgy9G4tBNn9EARLnS3Ofz3gMBgOPHMTtkso2gTXnftKdJc8CQsKV4V8ypw==}
+  graphql-lookahead@1.3.0:
+    resolution: {integrity: sha512-QQ+ecONjiEBGNkLJ01LQC5Iy9icM0Pb1vcSHhT15bQIdyDwRsct6kuINputo8b4Nyyu/GUz0DIJGjw/5CckluQ==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     peerDependencies:
       graphql: 16.x
@@ -6273,7 +6273,7 @@ snapshots:
     dependencies:
       graphql: 16.9.0
 
-  graphql-lookahead@1.3.0-beta.2(graphql@16.9.0):
+  graphql-lookahead@1.3.0(graphql@16.9.0):
     dependencies:
       graphql: 16.9.0
 


### PR DESCRIPTION
As per the title