### PR TITLE
fix: using getQueryInclude inside findOptions hook

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -62,13 +62,13 @@
   },
   "peerDependencies": {
     "graphql": "16.x",
-    "graphql-lookahead": "^1.2.1"
+    "graphql-lookahead": "^1.3.1-beta.3"
   },
   "devDependencies": {
     "@types/node": "^20.17.8",
     "dev-utils": "workspace:*",
     "graphql": "^16.9.0",
-    "graphql-lookahead": "^1.2.1",
+    "graphql-lookahead": "^1.3.1-beta.3",
     "typescript": "^5.7.2",
     "vite": "^6.0.1"
   },

--- a/packages/dev-playground/src/models/OrderItem/OrderItem.model.ts
+++ b/packages/dev-playground/src/models/OrderItem/OrderItem.model.ts
@@ -7,11 +7,13 @@ import {
   Model,
   Table,
 } from 'sequelize-typescript'
-import { defineGraphqlGeneConfig } from 'graphql-gene'
+import { defineGraphqlGeneConfig, extendTypes } from 'graphql-gene'
 import { Order } from '../Order/Order.model'
 import { Product } from '../Product/Product.model'
+import { getFieldFindOptions, getQueryInclude } from '@graphql-gene/plugin-sequelize'
 
-const PRODUCT_ASSOCIATION = 'product'
+const PRODUCT_ASSOCIATION = 'produit'
+const PRODUCT_ASSOCIATION_RENAMED = 'product'
 
 export
 @Table
@@ -39,6 +41,8 @@ class OrderItem extends Model {
   declare [PRODUCT_ASSOCIATION]: Product | null
 
   static readonly geneConfig = defineGraphqlGeneConfig(OrderItem, {
+    exclude: [PRODUCT_ASSOCIATION],
+
     findOptions({ findOptions }) {
       findOptions.include = findOptions.include || []
 
@@ -56,3 +60,42 @@ class OrderItem extends Model {
     },
   })
 }
+
+extendTypes({
+  OrderItem: {
+    /**
+     * Test case:
+     *   Rename the "produit" association to "product"
+     *
+     * To improve:
+     *   This field configuration has the same result as if we would have used
+     *   `resolver: 'default'`, but it doesn't make an additional query. It just feeds include
+     *   options to the root query.
+     *
+     *   We should change the `defaultResolver` to only make the query if the data is not already
+     *   available. If that would be the case, we could get rid of the big `findOptions` hook
+     *   below and configure the same behavior with only `resolver: 'default'`.
+     */
+    [PRODUCT_ASSOCIATION_RENAMED]: {
+      args: 'default',
+      returnType: 'Product',
+
+      resolver: ({ source }) => source[PRODUCT_ASSOCIATION],
+
+      findOptions({ findOptions, info, args, isList }) {
+        findOptions.include = findOptions.include || []
+
+        const topLevelFindOptions = getFieldFindOptions({ args, isList })
+        const includeOptions = getQueryInclude(info)
+
+        const possibleProductOptions = findOptions.include.find(
+          opt => opt.association === PRODUCT_ASSOCIATION
+        )
+        const productOptions = possibleProductOptions || { association: PRODUCT_ASSOCIATION }
+        if (!possibleProductOptions) findOptions.include.push(productOptions)
+
+        Object.assign(productOptions, topLevelFindOptions, includeOptions)
+      },
+    },
+  },
+})

--- a/packages/dev-playground/src/test/integration.spec.ts
+++ b/packages/dev-playground/src/test/integration.spec.ts
@@ -74,7 +74,8 @@ describe('integration', () => {
       it('returns null for each field returning the type with the directive', () => {
         expect(result.data?.order.items?.length).toBeTruthy()
         expect(
-          result.data?.order.items?.every(item => {
+          result.data?.order.items?.every(_item => {
+            const item = _item as unknown as { product?: Product }
             return (
               item.product?.variants?.length &&
               item.product?.variants?.every(variant => {
@@ -98,7 +99,8 @@ describe('integration', () => {
       it('returns the real value of each field returning the type with the directive', () => {
         expect(result.data?.order.items?.length).toBeTruthy()
         expect(
-          result.data?.order.items?.every(item => {
+          result.data?.order.items?.every(_item => {
+            const item = _item as unknown as { product?: Product }
             return (
               item.product?.variants?.length &&
               item.product?.variants?.every(variant => {
@@ -119,9 +121,11 @@ describe('integration', () => {
 
       it('returns null for each field having the directive', () => {
         expect(result.data?.order.items?.length).toBeTruthy()
-        expect(result.data?.order.items?.every(item => item.product?.isPublished === null)).toBe(
-          true
-        )
+        expect(
+          result.data?.order.items?.every(
+            item => (item as unknown as { product?: Product }).product?.isPublished === null
+          )
+        ).toBe(true)
       })
     })
 
@@ -134,7 +138,10 @@ describe('integration', () => {
       it('returns the real value of each field having the directive', () => {
         expect(result.data?.order.items?.length).toBeTruthy()
         expect(
-          result.data?.order.items?.every(item => typeof item.product?.isPublished === 'boolean')
+          result.data?.order.items?.every(
+            item =>
+              typeof (item as unknown as { product?: Product }).product?.isPublished === 'boolean'
+          )
         ).toBe(true)
       })
     })
@@ -152,9 +159,10 @@ describe('integration', () => {
         { headers: { 'x-test-size-filter-active': 'true' } }
       )
 
-      const apparelOrderItem = result.data?.order.items?.find(item =>
-        (item.product?.group?.categories as unknown as string[]).includes('apparel')
-      )
+      const apparelOrderItem = result.data?.order.items?.find(_item => {
+        const item = _item as unknown as { product?: Product }
+        return (item.product?.group?.categories as unknown as string[]).includes('apparel')
+      }) as unknown as { product?: Product }
       const apparelProduct = apparelOrderItem?.product
 
       it('filters out the XXL variants', () => {
@@ -173,9 +181,10 @@ describe('integration', () => {
         { headers: { 'x-test-size-filter-active': 'false' } }
       )
 
-      const apparelOrderItem = result.data?.order.items?.find(item =>
-        (item.product?.group?.categories as unknown as string[]).includes('apparel')
-      )
+      const apparelOrderItem = result.data?.order.items?.find(_item => {
+        const item = _item as unknown as { product?: Product }
+        return (item.product?.group?.categories as unknown as string[]).includes('apparel')
+      }) as unknown as { product?: Product }
       const apparelProduct = apparelOrderItem?.product
 
       it('does not filter out the XXL variants', () => {
@@ -212,11 +221,11 @@ describe('integration', () => {
 
       it('returns all items', () => {
         expect(result.data?.order.items?.length).toBeTruthy()
-        expect(result.data?.order.items?.map(item => item.product?.id)).toEqual([
-          firstProductId,
-          secondProductId,
-          thirdProductId,
-        ])
+        expect(
+          result.data?.order.items?.map(
+            item => (item as unknown as { product?: Product }).product?.id
+          )
+        ).toEqual([firstProductId, secondProductId, thirdProductId])
       })
     })
 
@@ -230,10 +239,11 @@ describe('integration', () => {
 
       it('returns all items except the one unpublished', () => {
         expect(result.data?.order.items?.length).toBeTruthy()
-        expect(result.data?.order.items?.map(item => item.product?.id)).toEqual([
-          firstProductId,
-          thirdProductId,
-        ])
+        expect(
+          result.data?.order.items?.map(
+            item => (item as unknown as { product?: Product }).product?.id
+          )
+        ).toEqual([firstProductId, thirdProductId])
       })
     })
   })

--- a/packages/plugin-sequelize/package.json
+++ b/packages/plugin-sequelize/package.json
@@ -56,7 +56,7 @@
     "sequelize-typescript": "2.x"
   },
   "dependencies": {
-    "graphql-lookahead": "^1.3.0"
+    "graphql-lookahead": "^1.3.1-beta.3"
   },
   "devDependencies": {
     "@types/node": "^20.17.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,8 +75,8 @@ importers:
         specifier: ^16.9.0
         version: 16.9.0
       graphql-lookahead:
-        specifier: ^1.2.1
-        version: 1.2.2(graphql@16.9.0)
+        specifier: ^1.3.1-beta.3
+        version: 1.3.1-beta.3(graphql@16.9.0)
       typescript:
         specifier: ^5.7.2
         version: 5.7.2
@@ -163,8 +163,8 @@ importers:
   packages/plugin-sequelize:
     dependencies:
       graphql-lookahead:
-        specifier: ^1.3.0
-        version: 1.3.0(graphql@16.9.0)
+        specifier: ^1.3.1-beta.3
+        version: 1.3.1-beta.3(graphql@16.9.0)
     devDependencies:
       '@types/node':
         specifier: ^20.17.8
@@ -2191,14 +2191,8 @@ packages:
   graphemer@1.4.0:
     resolution: {integrity: sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==}
 
-  graphql-lookahead@1.2.2:
-    resolution: {integrity: sha512-LPadjCwh+fidzhHCQUkTxyNEioMoKtlXH07Y3Yn+GPH73ADwCeVaV5HwRxarIC7014ZQA2Es/7WlJbmocDLHDg==}
-    engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
-    peerDependencies:
-      graphql: 16.x
-
-  graphql-lookahead@1.3.0:
-    resolution: {integrity: sha512-QQ+ecONjiEBGNkLJ01LQC5Iy9icM0Pb1vcSHhT15bQIdyDwRsct6kuINputo8b4Nyyu/GUz0DIJGjw/5CckluQ==}
+  graphql-lookahead@1.3.1-beta.3:
+    resolution: {integrity: sha512-erLYL6N46bQAPxySiZjrvHSnnSsmWN2SNPLJtWCSO3UjhgM2X16hUvTdPrr34/ZcWyKUWDLXyGUpN0nWi3bjXw==}
     engines: {node: ^12.22.0 || ^14.16.0 || ^16.0.0 || >=17.0.0}
     peerDependencies:
       graphql: 16.x
@@ -6269,11 +6263,7 @@ snapshots:
 
   graphemer@1.4.0: {}
 
-  graphql-lookahead@1.2.2(graphql@16.9.0):
-    dependencies:
-      graphql: 16.9.0
-
-  graphql-lookahead@1.3.0(graphql@16.9.0):
+  graphql-lookahead@1.3.1-beta.3(graphql@16.9.0):
     dependencies:
       graphql: 16.9.0
 


### PR DESCRIPTION
The `info` object provided by the `findOptions` hook was not specific to the current field so the result of `getQueryInclude` was inaccurate (only working at the root level).

This was fixed in https://github.com/accesimpot/graphql-lookahead/pull/104, so this PR simply upgrade `graphql-lookahead`.