### PR TITLE
docs(README): release update to local dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -630,8 +630,9 @@ type Query {
   ```bash
   # Install dependencies
   pnpm install
-  # or if you're having issues on Apple M Chips
-  arch -arm64 pnpm install -f
+  #
+  # or if you're having issues on Apple M Chips:
+  # arch -arm64 pnpm install -f
 
   # Develop
   pnpm playground: dev


### PR DESCRIPTION
The change was initially made in https://github.com/accesimpot/graphql-gene/pull/93, but it only triggered a sequelize-plugin release, so not update visible on the README of the core package.