### PR TITLE
ci: fix warnings in "if" inside release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,7 +79,7 @@ jobs:
           echo "count=${#projects_array[@]}" >> $GITHUB_OUTPUT
 
       - name: Build packages 📦
-        if: steps.public-package-affected.outputs.count > 0 || ${{ env.CI_FORCE_RELEASE_RUN }} == 'true'
+        if: ${{ steps.public-package-affected.outputs.count > 0 || env.CI_FORCE_RELEASE_RUN == 'true' }}
         run: pnpm build
 
       #
@@ -107,7 +107,7 @@ jobs:
       #   - revert: Reverts a previous commit
       #
       - name: Release
-        if: steps.public-package-affected.outputs.count > 0 || ${{ env.CI_FORCE_RELEASE_RUN }} == 'true'
+        if: ${{ steps.public-package-affected.outputs.count > 0 || env.CI_FORCE_RELEASE_RUN == 'true' }}
         env:
           # Give semantic-release the short-lived GitHub App token
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Fixing the following warnings in the release workflow:

> Conditional expression contains literal text outside replacement tokens. This will cause the expression to always evaluate to truthy. Did you mean to put the entire expression inside ${{ }}?