### PR TITLE
ci: add workflow_dispatch to release.yml with dry-run

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,11 @@ on:
     branches:
       - main
       - beta
+  #
+  # FOR TESTING PURPOSES ONLY!!!!
+  # TODO: Remove before merging
+  #
+  pull_request:
 
 # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
 permissions:
@@ -127,4 +132,7 @@ jobs:
         env:
           # Give semantic-release the short-lived GitHub App token
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-        run: pnpm -r --filter='!dev-*' --workspace-concurrency=1 exec semantic-release -e semantic-release-monorepo
+        run: |
+          set -euo pipefail
+          pnpm --filter graphql-gene exec -- semantic-release --dry-run -e semantic-release-monorepo
+          pnpm --filter @graphql-gene/plugin-sequelize exec -- semantic-release --dry-run -e semantic-release-monorepo

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,12 @@ on:
     branches:
       - main
       - beta
-  #
-  # FOR TESTING PURPOSES ONLY!!!!
-  # TODO: Remove before merging
-  #
-  pull_request:
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: Pass --dry-run to semantic-release (no version bump or publish)
+        type: boolean
+        default: false
 
 # https://docs.npmjs.com/trusted-publishers#step-2-configure-your-cicd-workflow
 permissions:
@@ -22,9 +23,6 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
-
-    env:
-      CI_FORCE_RELEASE_RUN: ${{ secrets.CI_FORCE_RELEASE_RUN }}
 
     steps:
       # https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#pushing-package.json-changes-to-your-repository
@@ -100,7 +98,7 @@ jobs:
           fi
 
       - name: Build packages 📦
-        if: ${{ steps.public-package-affected.outputs.count > 0 || env.CI_FORCE_RELEASE_RUN == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.public-package-affected.outputs.count > 0 }}
         run: pnpm build
 
       #
@@ -128,11 +126,14 @@ jobs:
       #   - revert: Reverts a previous commit
       #
       - name: Release
-        if: ${{ steps.public-package-affected.outputs.count > 0 || env.CI_FORCE_RELEASE_RUN == 'true' }}
+        if: ${{ github.event_name == 'workflow_dispatch' || steps.public-package-affected.outputs.count > 0 }}
         env:
           # Give semantic-release the short-lived GitHub App token
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
-          pnpm --filter graphql-gene exec -- semantic-release --dry-run -e semantic-release-monorepo
-          pnpm --filter @graphql-gene/plugin-sequelize exec -- semantic-release --dry-run -e semantic-release-monorepo
+          if [ "${{ github.event_name }}" = 'workflow_dispatch' ] && [ "${{ github.event.inputs.dry-run }}" = 'true' ]; then
+            pnpm -r --filter='!dev-*' --workspace-concurrency=1 exec -- semantic-release --dry-run -e semantic-release-monorepo
+          else
+            pnpm -r --filter='!dev-*' --workspace-concurrency=1 exec -- semantic-release -e semantic-release-monorepo
+          fi

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,8 +4,6 @@ export {
   generateDefaultQueryFilterTypeDefs,
 } from './defaultResolver'
 
-// DUMMY COMMENT (to remove)
-
 export * from './defineConfig'
 export * from './resolvers'
 export * from './schema'

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,8 @@ export {
   generateDefaultQueryFilterTypeDefs,
 } from './defaultResolver'
 
+// DUMMY COMMENT (to remove)
+
 export * from './defineConfig'
 export * from './resolvers'
 export * from './schema'


### PR DESCRIPTION
Add a `workflow_dispatch` trigger with a `dry-run` option to _release.yml_ so I can debug why OIDC suddenly started failing today with `404 OIDC token exchange error - package not found`

```
[12:05:39 PM] [semantic-release] [@semantic-release/npm] › ℹ  Verifying OIDC context for publishing from GitHub Actions
[12:05:39 PM] [semantic-release] [@semantic-release/npm] › ℹ  OIDC token exchange with the npm registry failed: 404 OIDC token exchange error - package not found
```