### PR TITLE
ci: skip release when beta is only rebased on main

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,48 @@ permissions:
   pull-requests: write # Required by @semantic-release/github to comment on released pull requests
 
 jobs:
+  should-proceed:
+    name: Proceed with the release?
+    runs-on: ubuntu-latest
+
+    outputs:
+      rebasing-beta: ${{ steps.rebasing-beta.outputs.rebasing }}
+
+    steps:
+      - name: Checkout branch 🛎
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Is rebasing beta?
+        id: rebasing-beta
+        run: |
+          github_ref="${{ github.ref }}"
+
+          if [[ $github_ref != 'refs/heads/beta' ]]; then
+            echo "rebasing=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+
+          changes=$(git diff HEAD..origin/main --name-only)
+
+          if [[ $? != 0 ]]; then
+            echo "rebasing=error" >> $GITHUB_OUTPUT
+          elif [[ $changes ]]; then
+            echo "rebasing=false" >> $GITHUB_OUTPUT
+          else
+            echo "rebasing=true" >> $GITHUB_OUTPUT
+          fi
+
   release:
     name: Release
+    needs: [should-proceed]
     runs-on: ubuntu-latest
 
     # Avoid re-running install/build/release when semantic-release pushes the version bump (same workflow).
     # GitHub Apps push as `{slug}[bot]` — adjust actor filter if that slug changes.
-    if: ${{ github.actor != 'acci-semantic-release-token[bot]' }}
+    if: ${{ github.actor != 'acci-semantic-release-token[bot]' && needs.should-proceed.outputs.rebasing-beta == 'false' }}
 
     steps:
       # https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#pushing-package.json-changes-to-your-repository


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds the same `should-proceed` job as [graphql-lookahead](https://github.com/accesimpot/graphql-lookahead/blob/main/.github/workflows/release.yml): on pushes to `beta`, if `git diff HEAD..origin/main` shows no file changes, the workflow treats the push as a pure rebase onto `main` and skips the `release` job so semantic-release does not run.

The existing `acci-semantic-release-token[bot]` guard on `release` is combined with `needs.should-proceed.outputs.rebasing-beta == 'false'` so both conditions must pass before install/build/release runs.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-42d06142-3376-4df3-8bb2-cde9897b250c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42d06142-3376-4df3-8bb2-cde9897b250c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

