### PR TITLE
ci: get app token before checkout to bypass push rulesets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,13 +60,11 @@ jobs:
     if: ${{ github.actor != 'acci-semantic-release-token[bot]' && needs.should-proceed.outputs.rebasing-beta == 'false' }}
 
     steps:
+      # Token before checkout so `actions/checkout` persists the App installation token (ruleset
+      # bypass). With only `persist-credentials: false`, pushes can fall back to the job’s
+      # default `GITHUB_TOKEN`, which cannot bypass “PR-only” rulesets — semantic-release then
+      # fails with `push declined due to repository rule violations`.
       # https://semantic-release.gitbook.io/semantic-release/recipes/ci-configurations/github-actions#pushing-package.json-changes-to-your-repository
-      - name: Checkout branch 🛎
-        uses: actions/checkout@v4
-        with:
-          persist-credentials: false # Required per semantic-release docs for GitHub Actions
-          fetch-depth: 0 # Required for nrwl/nx-set-shas
-
       - name: Get GitHub App token 🔐
         id: app-token
         uses: actions/create-github-app-token@v3
@@ -75,6 +73,12 @@ jobs:
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: ${{ github.repository_owner }}
           repositories: graphql-gene
+
+      - name: Checkout branch 🛎
+        uses: actions/checkout@v4
+        with:
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0 # Required for nrwl/nx-set-shas
 
       # NRWL action name refers to Nx “affected”, but the step only resolves robust base/head
       # SHAs for git and tools like Turborepo (`TURBO_SCM_BASE` / `--affected`). Nx does not


### PR DESCRIPTION
## Fix semantic-release push failures caused by ruleset bypass ordering

Moves the GitHub App token generation step **before** `actions/checkout` so the checkout action persists the App installation token as the credential for subsequent git operations.

Previously, checkout ran with `persist-credentials: false`, which caused pushes to fall back to the default `GITHUB_TOKEN`. Since `GITHUB_TOKEN` cannot bypass "PR-only" branch rulesets, semantic-release would fail with `push declined due to repository rule violations`.

By acquiring the App token first and passing it directly to `actions/checkout` via the `token` input, all git pushes made by semantic-release use the App installation token, which has the necessary permissions to bypass the ruleset.

## Merge plan

- Merge this to `main`
- Rebase `beta` on `main`
- Merge this small follow-up PR https://github.com/accesimpot/graphql-gene/pull/149 (only adding a comment) so it triggers the beta release again