### PR TITLE
ci: document major bumps in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,6 +145,11 @@ jobs:
       # { type: 'chore', scope: 'deps', release: 'patch' },
       # { type: 'docs', scope: 'README', release: 'patch' },
       #
+      # Major bumps: add `!` after the type (e.g. `feat!: ...`, `refactor!: ...`) and/or a `BREAKING CHANGE:` footer
+      # in the commit body (works for types other than `feat`). For prereleases of a new major,
+      # merge to `beta` first so npm gets `x.y.z-beta.n` on the `beta` dist-tag before shipping
+      # stable on `main`.
+      #
       # See https://github.com/conventional-changelog/conventional-changelog/tree/master/packages/conventional-changelog-angular#type
       #
       # Available types:


### PR DESCRIPTION
## Summary

Cherry-pick of [0db1858](https://github.com/accesimpot/graphql-gene/pull/143/commits/0db185884299110052fc60b01ee004ca167dbee4) from [#143](https://github.com/accesimpot/graphql-gene/pull/143).

Adds commented guidance in `.github/workflows/release.yml` for major bumps (`feat!` / `refactor!`, `BREAKING CHANGE:` footer) and shipping prereleases via `beta` first.

## Why

Follow-up PR to land only this change on `beta` and **trigger a new push** so the release workflow runs again (e.g. after rebasing `beta` onto `main` for the checkout/App-token fix).

Re-running the old failed workflow would **not** pick up newer workflow or commits on the branch.

Made with [Cursor](https://cursor.com)