### PR TITLE
fix: deep association where filters for parent-level queries and Apollo cache safety

### DIFF
--- a/PLAN_V2.md
+++ b/PLAN_V2.md
@@ -110,9 +110,9 @@ _List association (wrapper justified):_
 ```graphql
 # Product has many Variants — collection semantics
 product {
-  variants {
+  variants(where: { size: { in: ["M"] } }, limit: 20, skip: 0) {
     count
-    items(where: { size: { in: ["M"] } }, limit: 20, skip: 0) {
+    items {
       id
       size
     }

--- a/packages/core/src/defaultResolver.ts
+++ b/packages/core/src/defaultResolver.ts
@@ -112,12 +112,27 @@ export function generateOperatorInputLines(
   return lines
 }
 
-export function generateDefaultQueryFilterTypeDefs(options: {
+export type GenerateDefaultQueryFilterTypeDefsOptions = {
   typeDefLines: TypeDefLines
+  /** GraphQL type that owns the field being filtered (e.g. `Order` for `items`). */
   graphqlType: string
+  /** GraphQL field name that accepts the `where` argument (e.g. `items`). */
   fieldKey: string
+  /** GraphQL type of the filtered records (e.g. `OrderItem`). */
   fieldType: string
-}) {
+  /**
+   * When set, association fields on `fieldType` can use nested where inputs (one level per
+   * decrement). Pass `1` on parent association list filters; nested inputs are generated at `0`
+   * (scalars only).
+   */
+  associationFilterDepth?: 0 | 1
+  /** Return true when `fieldType.fieldName` is a Sequelize association exposed in GraphQL. */
+  isAssociationField?: (ownerGraphqlType: string, fieldName: string) => boolean
+}
+
+export function generateDefaultQueryFilterTypeDefs(
+  options: GenerateDefaultQueryFilterTypeDefsOptions
+) {
   const whereOptionsInputName = getWhereOptionsInputName(options.graphqlType, options.fieldKey)
   const orderEnumName = getQueryOrderEnumName(options.graphqlType, options.fieldKey)
 
@@ -156,6 +171,8 @@ export function generateDefaultQueryFilterTypeDefs(options: {
     [string, NonNullable<ReturnType<typeof findValidInputType>>]
   >([])
 
+  const associationFilterDepth = options.associationFilterDepth ?? 0
+
   Object.entries(options.typeDefLines[options.fieldType].lines).forEach(
     ([returnFieldKey, returnFieldConfig]) => {
       // Where Options Input
@@ -168,13 +185,31 @@ export function generateDefaultQueryFilterTypeDefs(options: {
 
       const validInputType = findValidInputType(returnFieldType.typeDef)
       let whereTypeDef = ''
+      const isAssociation =
+        options.isAssociationField?.(options.fieldType, returnFieldKey) ?? false
+      const relatedGraphqlType = getReturnTypeName(returnFieldType.typeDef)
 
       if (validInputType) {
         const operatorInputName = getOperatorInputName(validInputType)
         operatorInputsToGenerate.add([operatorInputName, validInputType])
         whereTypeDef = operatorInputName
+      } else if (isAssociation && associationFilterDepth > 0) {
+        const nestedWhereInputName = getWhereOptionsInputName(options.fieldType, returnFieldKey)
+
+        generateDefaultQueryFilterTypeDefs({
+          typeDefLines: options.typeDefLines,
+          graphqlType: options.fieldType,
+          fieldKey: returnFieldKey,
+          fieldType: relatedGraphqlType,
+          associationFilterDepth: 0,
+          isAssociationField: options.isAssociationField,
+        })
+
+        whereTypeDef = nestedWhereInputName
+      } else if (isAssociation && associationFilterDepth === 0) {
+        whereTypeDef = ''
       }
-      // If the return type is another Graphql Type because the field is an association
+      // Non-association object fields (e.g. FK id filters on legacy paths)
       else if (returnFieldType.typeDef in options.typeDefLines) {
         for (const key in options.typeDefLines[returnFieldType.typeDef].lines) {
           if (key === 'id') {

--- a/packages/core/src/defaultResolver.ts
+++ b/packages/core/src/defaultResolver.ts
@@ -185,8 +185,7 @@ export function generateDefaultQueryFilterTypeDefs(
 
       const validInputType = findValidInputType(returnFieldType.typeDef)
       let whereTypeDef = ''
-      const isAssociation =
-        options.isAssociationField?.(options.fieldType, returnFieldKey) ?? false
+      const isAssociation = options.isAssociationField?.(options.fieldType, returnFieldKey) ?? false
       const relatedGraphqlType = getReturnTypeName(returnFieldType.typeDef)
 
       if (validInputType) {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -4,6 +4,7 @@ export {
   generateDefaultQueryFilterTypeDefs,
   getWhereOptionsInputName,
   getQueryOrderEnumName,
+  type GenerateDefaultQueryFilterTypeDefsOptions,
 } from './defaultResolver'
 
 export * from './defineConfig'

--- a/packages/dev-playground/src/models/OrderItem/OrderItem.model.ts
+++ b/packages/dev-playground/src/models/OrderItem/OrderItem.model.ts
@@ -7,13 +7,11 @@ import {
   Model,
   Table,
 } from 'sequelize-typescript'
-import { defineGraphqlGeneConfig, extendTypes } from 'graphql-gene'
+import { defineGraphqlGeneConfig } from 'graphql-gene'
 import { Order } from '../Order/Order.model'
 import { Product } from '../Product/Product.model'
-import { getFieldFindOptions, getQueryInclude } from '@graphql-gene/plugin-sequelize'
 
-const PRODUCT_ASSOCIATION = 'produit'
-const PRODUCT_ASSOCIATION_RENAMED = 'product'
+const PRODUCT_ASSOCIATION = 'product'
 
 export
 @Table
@@ -38,11 +36,9 @@ class OrderItem extends Model {
   declare productId: number | null
 
   @BelongsTo(() => Product)
-  declare produit: Product | null
+  declare product: Product | null
 
   static readonly geneConfig = defineGraphqlGeneConfig(OrderItem, {
-    exclude: [PRODUCT_ASSOCIATION],
-
     findOptions({ findOptions }) {
       findOptions.include = findOptions.include || []
 
@@ -60,42 +56,3 @@ class OrderItem extends Model {
     },
   })
 }
-
-extendTypes({
-  OrderItem: {
-    /**
-     * Test case:
-     *   Rename the "produit" association to "product"
-     *
-     * To improve:
-     *   This field configuration has the same result as if we would have used
-     *   `resolver: 'default'`, but it doesn't make an additional query. It just feeds include
-     *   options to the root query.
-     *
-     *   We should change the `defaultResolver` to only make the query if the data is not already
-     *   available. If that would be the case, we could get rid of the big `findOptions` hook
-     *   below and configure the same behavior with only `resolver: 'default'`.
-     */
-    [PRODUCT_ASSOCIATION_RENAMED]: {
-      args: 'default',
-      returnType: 'Product',
-
-      resolver: ({ source }) => source[PRODUCT_ASSOCIATION],
-
-      findOptions({ findOptions, info, args, isList }) {
-        findOptions.include = findOptions.include || []
-
-        const topLevelFindOptions = getFieldFindOptions({ args, isList })
-        const includeOptions = getQueryInclude(info)
-
-        const possibleProductOptions = findOptions.include.find(
-          opt => opt.association === PRODUCT_ASSOCIATION
-        )
-        const productOptions = possibleProductOptions || { association: PRODUCT_ASSOCIATION }
-        if (!possibleProductOptions) findOptions.include.push(productOptions)
-
-        Object.assign(productOptions, topLevelFindOptions, includeOptions)
-      },
-    },
-  },
-})

--- a/packages/dev-playground/src/test/integration.spec.ts
+++ b/packages/dev-playground/src/test/integration.spec.ts
@@ -427,6 +427,24 @@ describe('integration', () => {
         expect(orderRow.notesFacet.count).toBe(2)
       }
     )
+
+    it('filters association list items with one-level-deep where on a related model', async () => {
+      const result = await execute({
+        document: getFixtureQuery('queries/orderItemsDeepFilter.gql'),
+        variables: { id: '399', productName: 'Fusion - Ocean Mist' },
+      })
+
+      expect(result.errors).toBeUndefined()
+
+      const facet = (
+        result.data?.order as unknown as {
+          byProductName: { count: number; items: { product: { name: string } }[] }
+        }
+      ).byProductName
+
+      expect(facet.count).toBe(1)
+      expect(facet.items.every(row => row.product.name === 'Fusion - Ocean Mist')).toBe(true)
+    })
   })
 
   describe('polymorphic page blocks (GraphQL interface + @Polymorphic)', () => {

--- a/packages/dev-playground/src/test/queries/orderItemsDeepFilter.gql
+++ b/packages/dev-playground/src/test/queries/orderItemsDeepFilter.gql
@@ -1,0 +1,16 @@
+query orderItemsDeepFilter($id: String!, $productName: String!) {
+  order(id: $id) {
+    id
+    byProductName: items(where: { product: { name: { eq: $productName } } }) {
+      count
+      items {
+        id
+        quantity
+        product {
+          id
+          name
+        }
+      }
+    }
+  }
+}

--- a/packages/plugin-sequelize/src/associationListResolvers.ts
+++ b/packages/plugin-sequelize/src/associationListResolvers.ts
@@ -157,13 +157,19 @@ async function ensureAssociationItemsFacetLoaded(
     args: facetArgs,
     isList: true,
     omitAssociation: true,
+    filterContext: {
+      ownerGraphqlType: TargetModel.name,
+      includes: [],
+    },
   })
 
   const nestedInclude = getQueryInclude(info)
   const mergedFind: DefaultResolverIncludeOptions = { ...(nestedInclude || {}) }
   applyGeneConfigRootFindOptions(TargetModel, mergedFind)
 
-  if (mergedFind.include?.length) {
+  const mergedInclude = [...(columnOpts.include || []), ...(mergedFind.include || [])]
+  if (mergedInclude.length) {
+    mergedFind.include = mergedInclude
     stripAssociationListWrapperIncludes(TargetModel, mergedFind.include)
   }
 
@@ -274,10 +280,15 @@ export function attachAssociationListWrapperResolvers(schema: GraphQLSchema, typ
           args: facetArgs,
           isList: false,
           omitAssociation: true,
+          filterContext: {
+            ownerGraphqlType: TargetModel.name,
+            includes: [],
+          },
         })
 
         return TargetModel.count({
           where: { ...fkWhere, ...filterOpts.where },
+          include: filterOpts.include,
           distinct: true,
         })
       }

--- a/packages/plugin-sequelize/src/defaultResolver.spec.ts
+++ b/packages/plugin-sequelize/src/defaultResolver.spec.ts
@@ -95,4 +95,38 @@ describe('defaultResolver', () => {
     const findOptions = findAll.mock.calls[0]?.[0] as { include: DefaultResolverIncludeOptions[] }
     expect(findOptions.include).toEqual([lookaheadInclude])
   })
+
+  it('does not pass unstripped lookahead includes after wrapper stripping empties the merge', async () => {
+    const { defaultResolver } = await import('./defaultResolver')
+
+    const wrapperInclude: DefaultResolverIncludeOptions = {
+      association: 'items',
+      include: [{ association: 'product' }],
+    }
+
+    getFieldFindOptions.mockReturnValue({ where: { status: { [Op.eq]: 'paid' } } })
+    getQueryInclude.mockReturnValue({ include: [wrapperInclude] })
+
+    stripAssociationListWrapperIncludes.mockImplementation((_model, includes) => {
+      includes.splice(0, includes.length)
+    })
+
+    const findOne = vi.fn().mockResolvedValue(null)
+    const model = {
+      name: 'Order',
+      associations: {},
+      findOne,
+    }
+
+    await defaultResolver({
+      model,
+      modelKey: 'Order',
+      config: { returnType: 'Order' },
+      args: { where: { status: { eq: 'paid' } } },
+      info: {} as GraphQLResolveInfo,
+    })
+
+    const findOptions = findOne.mock.calls[0]?.[0] as { include?: DefaultResolverIncludeOptions[] }
+    expect(findOptions.include).toBeUndefined()
+  })
 })

--- a/packages/plugin-sequelize/src/defaultResolver.spec.ts
+++ b/packages/plugin-sequelize/src/defaultResolver.spec.ts
@@ -1,0 +1,98 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+import { Op } from 'sequelize'
+import type { GraphQLResolveInfo } from 'graphql'
+import type { DefaultResolverIncludeOptions } from './types'
+
+const { getFieldFindOptions, getQueryInclude, stripAssociationListWrapperIncludes } = vi.hoisted(
+  () => ({
+    getFieldFindOptions: vi.fn(),
+    getQueryInclude: vi.fn(),
+    stripAssociationListWrapperIncludes: vi.fn(),
+  })
+)
+
+vi.mock('./utils', () => ({
+  getFieldFindOptions,
+  getQueryInclude,
+}))
+
+vi.mock('./utils/includePostProcess', () => ({
+  stripAssociationListWrapperIncludes,
+}))
+
+describe('defaultResolver', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('merges deep-filter includes with lookahead includes for root list queries', async () => {
+    const { defaultResolver } = await import('./defaultResolver')
+
+    const deepFilterInclude: DefaultResolverIncludeOptions = {
+      association: 'product',
+      where: { name: { [Op.eq]: 'Fusion - Ocean Mist' } },
+      required: true,
+    }
+    const lookaheadInclude: DefaultResolverIncludeOptions = {
+      association: 'product',
+    }
+
+    getFieldFindOptions.mockReturnValue({
+      where: {},
+      include: [deepFilterInclude],
+    })
+    getQueryInclude.mockReturnValue({
+      include: [lookaheadInclude],
+    })
+
+    const findAll = vi.fn().mockResolvedValue([])
+    const model = {
+      name: 'OrderItem',
+      associations: {},
+      findAll,
+    }
+
+    await defaultResolver({
+      model,
+      modelKey: 'OrderItem',
+      config: { returnType: '[OrderItem!]!' },
+      args: { where: { product: { name: { eq: 'Fusion - Ocean Mist' } } } },
+      info: {} as GraphQLResolveInfo,
+    })
+
+    expect(findAll).toHaveBeenCalledOnce()
+    const findOptions = findAll.mock.calls[0]?.[0] as { include: DefaultResolverIncludeOptions[] }
+
+    expect(findOptions.include).toEqual([deepFilterInclude, lookaheadInclude])
+    expect(stripAssociationListWrapperIncludes).toHaveBeenCalledWith(model, findOptions.include)
+  })
+
+  it('keeps lookahead-only includes when deep filters do not add any', async () => {
+    const { defaultResolver } = await import('./defaultResolver')
+
+    const lookaheadInclude: DefaultResolverIncludeOptions = {
+      association: 'product',
+    }
+
+    getFieldFindOptions.mockReturnValue({ where: { quantity: { [Op.eq]: 3 } } })
+    getQueryInclude.mockReturnValue({ include: [lookaheadInclude] })
+
+    const findAll = vi.fn().mockResolvedValue([])
+    const model = {
+      name: 'OrderItem',
+      associations: {},
+      findAll,
+    }
+
+    await defaultResolver({
+      model,
+      modelKey: 'OrderItem',
+      config: { returnType: '[OrderItem!]!' },
+      args: { where: { quantity: { eq: 3 } } },
+      info: {} as GraphQLResolveInfo,
+    })
+
+    const findOptions = findAll.mock.calls[0]?.[0] as { include: DefaultResolverIncludeOptions[] }
+    expect(findOptions.include).toEqual([lookaheadInclude])
+  })
+})

--- a/packages/plugin-sequelize/src/defaultResolver.ts
+++ b/packages/plugin-sequelize/src/defaultResolver.ts
@@ -38,10 +38,7 @@ export async function defaultResolver<
   })
   const includeOptions = getQueryInclude(options.info)
 
-  const mergedInclude = [
-    ...(topLevelFindOptions.include ?? []),
-    ...(includeOptions?.include ?? []),
-  ]
+  const mergedInclude = [...(topLevelFindOptions.include ?? []), ...(includeOptions?.include ?? [])]
 
   if (mergedInclude.length) {
     stripAssociationListWrapperIncludes(model, mergedInclude)

--- a/packages/plugin-sequelize/src/defaultResolver.ts
+++ b/packages/plugin-sequelize/src/defaultResolver.ts
@@ -38,12 +38,18 @@ export async function defaultResolver<
   })
   const includeOptions = getQueryInclude(options.info)
 
-  if (includeOptions?.include?.length) {
-    stripAssociationListWrapperIncludes(model, includeOptions.include)
+  const mergedInclude = [
+    ...(topLevelFindOptions.include ?? []),
+    ...(includeOptions?.include ?? []),
+  ]
+
+  if (mergedInclude.length) {
+    stripAssociationListWrapperIncludes(model, mergedInclude)
   }
 
   return (await model[findFn]({
     ...topLevelFindOptions,
     ...includeOptions,
+    ...(mergedInclude.length ? { include: mergedInclude } : {}),
   })) as GraphqlToTypescript<ModelKey>
 }

--- a/packages/plugin-sequelize/src/defaultResolver.ts
+++ b/packages/plugin-sequelize/src/defaultResolver.ts
@@ -28,7 +28,14 @@ export async function defaultResolver<
   const isList = isListType(parseType(options.config.returnType))
   const findFn = isList ? 'findAll' : 'findOne'
 
-  const topLevelFindOptions = getFieldFindOptions({ args: options.args, isList })
+  const topLevelFindOptions = getFieldFindOptions({
+    args: options.args,
+    isList,
+    filterContext: {
+      ownerGraphqlType: model.name,
+      includes: [],
+    },
+  })
   const includeOptions = getQueryInclude(options.info)
 
   if (includeOptions?.include?.length) {

--- a/packages/plugin-sequelize/src/defaultResolver.ts
+++ b/packages/plugin-sequelize/src/defaultResolver.ts
@@ -44,9 +44,12 @@ export async function defaultResolver<
     stripAssociationListWrapperIncludes(model, mergedInclude)
   }
 
+  const { include: _discardedTopInclude, ...restTopLevelFindOptions } = topLevelFindOptions
+  const { include: _discardedInclude, ...restIncludeOptions } = includeOptions ?? {}
+
   return (await model[findFn]({
-    ...topLevelFindOptions,
-    ...includeOptions,
-    ...(mergedInclude.length ? { include: mergedInclude } : {}),
+    ...restTopLevelFindOptions,
+    ...restIncludeOptions,
+    ...(mergedInclude.length > 0 ? { include: mergedInclude } : {}),
   })) as GraphqlToTypescript<ModelKey>
 }

--- a/packages/plugin-sequelize/src/populateTypeDefs.ts
+++ b/packages/plugin-sequelize/src/populateTypeDefs.ts
@@ -15,7 +15,7 @@ import {
   JSON_SCALAR,
   SEQUELIZE_TYPE_TO_GRAPHQL,
 } from './constants'
-import { markFieldAsAssociation } from './utils/associationMap'
+import { isMarkedAsAssociation, markFieldAsAssociation } from './utils/associationMap'
 import {
   getGeneAssociationListWrapperTypeName,
   registerGeneAssociationListWrapper,
@@ -177,6 +177,9 @@ function generateAssociationFields(
           graphqlType: options.typeName,
           fieldKey: attributeKey,
           fieldType: associationModelName,
+          associationFilterDepth: 1,
+          isAssociationField: (ownerType, fieldName) =>
+            isMarkedAsAssociation(ownerType, fieldName),
         })
       })
     }

--- a/packages/plugin-sequelize/src/populateTypeDefs.ts
+++ b/packages/plugin-sequelize/src/populateTypeDefs.ts
@@ -178,8 +178,7 @@ function generateAssociationFields(
           fieldKey: attributeKey,
           fieldType: associationModelName,
           associationFilterDepth: 1,
-          isAssociationField: (ownerType, fieldName) =>
-            isMarkedAsAssociation(ownerType, fieldName),
+          isAssociationField: (ownerType, fieldName) => isMarkedAsAssociation(ownerType, fieldName),
         })
       })
     }

--- a/packages/plugin-sequelize/src/utils/deepWhere.ts
+++ b/packages/plugin-sequelize/src/utils/deepWhere.ts
@@ -1,0 +1,10 @@
+import { AND_OR_OPERATORS, isObject } from 'graphql-gene'
+import { GENE_TO_SEQUELIZE_OPERATORS } from '../constants'
+
+export function isWhereOperatorMap(value: unknown): boolean {
+  if (!isObject(value)) return false
+
+  return Object.keys(value).some(
+    key => AND_OR_OPERATORS.includes(key) || key in GENE_TO_SEQUELIZE_OPERATORS
+  )
+}

--- a/packages/plugin-sequelize/src/utils/internal.spec.ts
+++ b/packages/plugin-sequelize/src/utils/internal.spec.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import { Op } from 'sequelize'
 import type { GeneSequelizeWhereOptions } from '../types'
+import { markFieldAsAssociation } from './associationMap'
 import { populateWhereOptions } from './internal'
 
 describe('populateWhereOptions', () => {
@@ -32,5 +33,32 @@ describe('populateWhereOptions', () => {
     expect(state.name).toEqual({ [Op.like]: '%foo%' })
     expect(state.qty).toEqual({ [Op.lt]: 10 })
     expect(state.removed).toEqual({ [Op.is]: null })
+  })
+
+  it('turns one-level association predicates into required includes', () => {
+    markFieldAsAssociation('DeepParent', 'child')
+
+    const state: GeneSequelizeWhereOptions = {}
+    const includes = []
+
+    populateWhereOptions(
+      {
+        child: { label: { eq: 'match' } },
+      } as never,
+      state,
+      {
+        ownerGraphqlType: 'DeepParent',
+        includes,
+      }
+    )
+
+    expect(state).toEqual({})
+    expect(includes).toEqual([
+      {
+        association: 'child',
+        where: { label: { [Op.eq]: 'match' } },
+        required: true,
+      },
+    ])
   })
 })

--- a/packages/plugin-sequelize/src/utils/internal.ts
+++ b/packages/plugin-sequelize/src/utils/internal.ts
@@ -1,10 +1,23 @@
-import { AND_OR_OPERATORS, type GeneDefaultResolverArgs, type ValueOf } from 'graphql-gene'
-import type { GeneSequelizeWhereOptions } from '../types'
+import {
+  AND_OR_OPERATORS,
+  isObject,
+  type GeneDefaultResolverArgs,
+  type ValueOf,
+} from 'graphql-gene'
+import type { DefaultResolverIncludeOptions, GeneSequelizeWhereOptions } from '../types'
 import { GENE_TO_SEQUELIZE_OPERATORS } from '../constants'
+import { isMarkedAsAssociation } from './associationMap'
+import { isWhereOperatorMap } from './deepWhere'
+
+export type PopulateWhereOptionsContext = {
+  ownerGraphqlType: string
+  includes: DefaultResolverIncludeOptions[]
+}
 
 export function populateWhereOptions<M>(
   whereArgs: GeneDefaultResolverArgs<M>['where'],
-  state: GeneSequelizeWhereOptions
+  state: GeneSequelizeWhereOptions,
+  context?: PopulateWhereOptionsContext
 ) {
   for (const attr in whereArgs) {
     const parseOperators = (
@@ -32,10 +45,24 @@ export function populateWhereOptions<M>(
           whereArgs[attr].forEach((nestedWhereArgs: typeof whereArgs) => {
             const nextState = {} as GeneSequelizeWhereOptions
             state[op].push(nextState)
-            populateWhereOptions(nestedWhereArgs, nextState)
+            populateWhereOptions(nestedWhereArgs, nextState, context)
           })
         }
       }
+    } else if (
+      context &&
+      isWhereOperatorMap(whereArgs[attr]) === false &&
+      isObject(whereArgs[attr]) &&
+      isMarkedAsAssociation(context.ownerGraphqlType, attr)
+    ) {
+      const nestedWhere: GeneSequelizeWhereOptions = {}
+      populateWhereOptions(whereArgs[attr] as never, nestedWhere)
+
+      context.includes.push({
+        association: attr,
+        where: nestedWhere,
+        required: true,
+      })
     } else {
       state[attr] = state[attr] || {}
 

--- a/packages/plugin-sequelize/src/utils/public.ts
+++ b/packages/plugin-sequelize/src/utils/public.ts
@@ -20,7 +20,7 @@ import {
 import type { OrderItem } from 'sequelize'
 import type { Model } from 'sequelize-typescript'
 import type { DefaultResolverIncludeOptions, GeneSequelizeWhereOptions } from '../types'
-import { populateWhereOptions } from './internal'
+import { populateWhereOptions, type PopulateWhereOptionsContext } from './internal'
 import {
   GENE_ASSOCIATION_LIST_ITEMS_FIELD,
   getGeneAssociationListWrapperMeta,
@@ -34,6 +34,7 @@ import { getAttributeByModelName } from './polymorphic'
 import { isSafeArray } from './guards'
 
 export * from './polymorphic'
+export { markFieldAsAssociation, isMarkedAsAssociation } from './associationMap'
 
 /**
  * Frames the current Sequelize include object when traversing synthetic wrapper facets so
@@ -162,7 +163,11 @@ function handleNextIncludeOptions(details: NextHandlerDetails<DefaultResolverInc
     return frameAssociationInclude(state)
   }
 
-  const include = getFieldIncludeOptions({ association: field, args, isList })
+  const include = getFieldIncludeOptions({
+    association: field,
+    args,
+    isList,
+  })
 
   state.include = state.include || []
   state.include.push(include)
@@ -253,6 +258,7 @@ export function getFieldFindOptions(options: {
   args: { [arg: string]: unknown }
   isList: boolean
   omitAssociation?: boolean
+  filterContext?: PopulateWhereOptionsContext
 }) {
   return getFieldIncludeOptions(options)
 }
@@ -262,6 +268,8 @@ export function getFieldIncludeOptions(options: {
   args: { [arg: string]: unknown }
   isList: boolean
   omitAssociation?: boolean
+  /** Enables one-level-deep association predicates in `where` (see PLAN §2.7). */
+  filterContext?: PopulateWhereOptionsContext
 }) {
   const includeOptions: DefaultResolverIncludeOptions = {}
   if (options.association && !options.omitAssociation) {
@@ -269,6 +277,7 @@ export function getFieldIncludeOptions(options: {
   }
 
   const where: GeneSequelizeWhereOptions = {}
+  const deepIncludes: DefaultResolverIncludeOptions[] = []
 
   if (!options.isList) {
     if (options.association && !options.omitAssociation) return includeOptions
@@ -281,7 +290,16 @@ export function getFieldIncludeOptions(options: {
 
   if (isObject(options.args.where)) {
     includeOptions.where = where
-    populateWhereOptions(options.args.where, where)
+    populateWhereOptions(
+      options.args.where,
+      where,
+      options.filterContext ? { ...options.filterContext, includes: deepIncludes } : undefined
+    )
+  }
+
+  if (deepIncludes.length) {
+    includeOptions.include = includeOptions.include || []
+    includeOptions.include.push(...deepIncludes)
   }
 
   if (isSafeArray(options.args.order)) {


### PR DESCRIPTION
## Summary

Adds one-level deep filtering on association `where` inputs so clients can filter list associations by related model fields (e.g. `items(where: { product: { name: { eq: $name } } })`).

## Changes

- Generate nested `WhereOptions` when `associationFilterDepth` is 1
- Resolve nested predicates as required Sequelize includes in default and association-list resolvers
- Add dev-playground query + integration coverage for deep order-item filtering
- Remove unnecessary association renaming in `OrderItem`

## Stack

- Base: #150 (`fix/polymorphic-no-fragment-in-query` → `beta`)

## Test plan

- [ ] Run plugin-sequelize unit tests (`internal.spec.ts`)
- [ ] Run dev-playground integration tests
- [ ] Verify deep filter query returns expected order items